### PR TITLE
docs(vite): correct the inverted shebang/library-mode jsdoc

### DIFF
--- a/packages/vite-lib-config/docs/functions/viteConfig.md
+++ b/packages/vite-lib-config/docs/functions/viteConfig.md
@@ -11,14 +11,15 @@
 Create a Vite configuration for the current project.
 
 The entry point is `src/index.mts` under the provided working directory.
-When every entry file starts with a shebang(`#!...`), the build treats
-them as executables: no `build.lib` and no declaration output. When any
-entry does not, the build runs in library mode with declaration output
-instead — since the check requires every entry to have a shebang, a
-mixed set of entries also falls into library mode. Both branches build
-with `ssr: true` unconditionally. An entry file that does not exist on
-disk is filtered out, and an empty result yields an empty
-configuration. Additional settings can override these defaults via
+Entries that do not exist on disk are filtered out first; if none
+remain, the result is an empty configuration. Among the remaining
+entries, when every file starts with a shebang(`#!...`), the build
+treats them as executables: no `build.lib` and no declaration output.
+When any entry does not, the build runs in library mode with
+declaration output instead — since the check requires every remaining
+entry to have a shebang, a mixed set of entries also falls into
+library mode. Both branches build with `ssr: true` unconditionally.
+Additional settings can override these defaults via
 mergeConfig.
 
 ## Parameters

--- a/packages/vite-lib-config/docs/functions/viteConfig.md
+++ b/packages/vite-lib-config/docs/functions/viteConfig.md
@@ -11,9 +11,15 @@
 Create a Vite configuration for the current project.
 
 The entry point is `src/index.mts` under the provided working directory.
-If the file starts with a shebang(`#!...`), the build uses library mode;
-otherwise it performs an SSR build. Additional settings can override
-these defaults via mergeConfig.
+When every entry file starts with a shebang(`#!...`), the build treats
+them as executables: no `build.lib` and no declaration output. When any
+entry does not, the build runs in library mode with declaration output
+instead — since the check requires every entry to have a shebang, a
+mixed set of entries also falls into library mode. Both branches build
+with `ssr: true` unconditionally. An entry file that does not exist on
+disk is filtered out, and an empty result yields an empty
+configuration. Additional settings can override these defaults via
+mergeConfig.
 
 ## Parameters
 

--- a/packages/vite-lib-config/docs/functions/vitestConfig.md
+++ b/packages/vite-lib-config/docs/functions/vitestConfig.md
@@ -10,9 +10,9 @@
 
 Create a Vitest configuration for the current project.
 
-The entry point is `src/index.mts` under the provided working directory.
-If the file starts with a shebang(`#!...`), the build uses library mode;
-otherwise it performs an SSR build. Additional settings can override
+Merges a `test.environment: 'node'` default under the [viteConfig](viteConfig.md)
+produced for the same entry point, so Vitest inherits the same build
+settings the project builds with. Additional settings can override
 these defaults via mergeConfig.
 
 ## Parameters

--- a/packages/vite-lib-config/src/vite.mts
+++ b/packages/vite-lib-config/src/vite.mts
@@ -54,9 +54,14 @@ const staticConfig = {
 /**
  * Creates a Vite configuration based on the provided entry point.
  *
- * The entry point is `src/index.mts` under the provided working directory.
- * If the file starts with a shebang(`#!...`), the build uses library mode;
- * otherwise it performs an SSR build.
+ * When every file in `entries` starts with a shebang(`#!...`), the build
+ * treats them as executables: no `build.lib` and no declaration output.
+ * When any entry does not, the build runs in library mode with
+ * {@link dts} emitting declarations instead — since the check requires
+ * every entry to have a shebang, a mixed set (some with, some without)
+ * also falls into library mode. Both branches build with `ssr: true`
+ * unconditionally. When no file in `entries` exists on disk, the result
+ * is an empty configuration.
  * @param entries Entry point files for the Vite configuration.
  * @return A Vite {@link UserConfig} object with the configuration
  */
@@ -79,9 +84,15 @@ const innerCreateConfig = (entries: readonly string[]): UserConfig => {
  * Create a Vite configuration for the current project.
  *
  * The entry point is `src/index.mts` under the provided working directory.
- * If the file starts with a shebang(`#!...`), the build uses library mode;
- * otherwise it performs an SSR build. Additional settings can override
- * these defaults via {@link mergeConfig}.
+ * When every entry file starts with a shebang(`#!...`), the build treats
+ * them as executables: no `build.lib` and no declaration output. When any
+ * entry does not, the build runs in library mode with declaration output
+ * instead — since the check requires every entry to have a shebang, a
+ * mixed set of entries also falls into library mode. Both branches build
+ * with `ssr: true` unconditionally. An entry file that does not exist on
+ * disk is filtered out, and an empty result yields an empty
+ * configuration. Additional settings can override these defaults via
+ * {@link mergeConfig}.
  * @param overrides Additional configuration options to merge with the base
  * config.
  * @param options Options for creating the config, including the working

--- a/packages/vite-lib-config/src/vite.mts
+++ b/packages/vite-lib-config/src/vite.mts
@@ -54,14 +54,15 @@ const staticConfig = {
 /**
  * Creates a Vite configuration based on the provided entry point.
  *
- * When every file in `entries` starts with a shebang(`#!...`), the build
+ * Entries that do not exist on disk are filtered out first; if none
+ * remain, the result is an empty configuration. Among the remaining
+ * entries, when every file starts with a shebang(`#!...`), the build
  * treats them as executables: no `build.lib` and no declaration output.
  * When any entry does not, the build runs in library mode with
  * {@link dts} emitting declarations instead — since the check requires
- * every entry to have a shebang, a mixed set (some with, some without)
- * also falls into library mode. Both branches build with `ssr: true`
- * unconditionally. When no file in `entries` exists on disk, the result
- * is an empty configuration.
+ * every remaining entry to have a shebang, a mixed set (some with, some
+ * without) also falls into library mode. Both branches build with
+ * `ssr: true` unconditionally.
  * @param entries Entry point files for the Vite configuration.
  * @return A Vite {@link UserConfig} object with the configuration
  */
@@ -84,14 +85,15 @@ const innerCreateConfig = (entries: readonly string[]): UserConfig => {
  * Create a Vite configuration for the current project.
  *
  * The entry point is `src/index.mts` under the provided working directory.
- * When every entry file starts with a shebang(`#!...`), the build treats
- * them as executables: no `build.lib` and no declaration output. When any
- * entry does not, the build runs in library mode with declaration output
- * instead — since the check requires every entry to have a shebang, a
- * mixed set of entries also falls into library mode. Both branches build
- * with `ssr: true` unconditionally. An entry file that does not exist on
- * disk is filtered out, and an empty result yields an empty
- * configuration. Additional settings can override these defaults via
+ * Entries that do not exist on disk are filtered out first; if none
+ * remain, the result is an empty configuration. Among the remaining
+ * entries, when every file starts with a shebang(`#!...`), the build
+ * treats them as executables: no `build.lib` and no declaration output.
+ * When any entry does not, the build runs in library mode with
+ * declaration output instead — since the check requires every remaining
+ * entry to have a shebang, a mixed set of entries also falls into
+ * library mode. Both branches build with `ssr: true` unconditionally.
+ * Additional settings can override these defaults via
  * {@link mergeConfig}.
  * @param overrides Additional configuration options to merge with the base
  * config.

--- a/packages/vite-lib-config/src/vitest.mts
+++ b/packages/vite-lib-config/src/vitest.mts
@@ -11,9 +11,9 @@ const staticConfig = {
 /**
  * Create a Vitest configuration for the current project.
  *
- * The entry point is `src/index.mts` under the provided working directory.
- * If the file starts with a shebang(`#!...`), the build uses library mode;
- * otherwise it performs an SSR build. Additional settings can override
+ * Merges a `test.environment: 'node'` default under the {@link viteConfig}
+ * produced for the same entry point, so Vitest inherits the same build
+ * settings the project builds with. Additional settings can override
  * these defaults via {@link mergeConfig}.
  * @param overrides Additional configuration options to merge with the base
  * config.


### PR DESCRIPTION
## Summary

`viteConfig`'s and `vitestConfig`'s published JSDoc (rendered by
typedoc into `packages/vite-lib-config/docs/functions/*.md`, which is
committed and shipped in the package's npm `files`) stated the inverse
of the actual behavior: it claimed a shebang selects library mode and
that only the non-shebang branch is an SSR build.

The implementation does the opposite:

- A shebang means **no** `build.lib` and **no** declaration output
  (built as an executable); its absence enables library mode with
  `vite-plugin-dts` emitting declarations.
- `staticConfig` sets `ssr: true` unconditionally — **both** branches
  are SSR builds.
- The same wrong paragraph was copied onto `vitestConfig`, which
  returns a Vitest config, not a build.

## Changes

- Rewrote `innerCreateConfig`'s and `viteConfig`'s JSDoc to describe
  the real branch, plus two behaviors the old text never mentioned:
  the shebang check uses `Array.prototype.every`, so a mixed set of
  entries (some with a shebang, some without) falls into library mode
  too; and an entry file that doesn't exist on disk is filtered out,
  with an empty result yielding an empty config.
- Rewrote `vitestConfig`'s JSDoc to describe what it does: merge a
  `test.environment: 'node'` default under `viteConfig`'s output.
- Regenerated the committed typedoc output
  (`pnpm --filter @kurone-kito/vite-lib-config run build:doc`) so the
  published docs match.

Documentation only — `git diff --stat` touches the two `src/*.mts`
docblocks and the two generated `docs/*.md` files, no spec file. The
4 pre-existing typedoc warnings (`mergeConfig`/`UserConfig`/
`ViteUserConfig` links not included in the docs) are unchanged in
count.

## Verification

- `pnpm --filter @kurone-kito/vite-lib-config run build:doc` followed
  by `git diff --exit-code packages/vite-lib-config/docs` is clean.
- `vite.spec.mts` / `vitest.spec.mts` assertions unchanged, still pass
  (they already asserted the real behavior this PR now documents).
- `pnpm run lint && pnpm run build && pnpm run test` — all pass.

Closes #60
