### PR TITLE
fix(sea-builder,example-cli): pass env's multi-word shebang arg with -S

### DIFF
--- a/packages/example-cli/src/index.mts
+++ b/packages/example-cli/src/index.mts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node --enable-source-maps
+#!/usr/bin/env -S node --enable-source-maps
 
 import HelloWorld from '@kurone-kito/example-lib';
 

--- a/packages/sea-builder/src/builder.mts
+++ b/packages/sea-builder/src/builder.mts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node --enable-source-maps
+#!/usr/bin/env -S node --enable-source-maps
 
 import { isNativeError } from 'node:util/types';
 import { createBuildTasks } from './listr2/createBuildTasks.mjs';

--- a/packages/sea-builder/src/cache.mts
+++ b/packages/sea-builder/src/cache.mts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node --enable-source-maps
+#!/usr/bin/env -S node --enable-source-maps
 
 import { createListrCacheTasks } from './listr2/createCacheTasks.mjs';
 import { runIfMain } from './utils/runIfMain.mjs';


### PR DESCRIPTION
## Summary

Three executable entry points shared the same broken shebang:

```text
#!/usr/bin/env node --enable-source-maps
```

A `#!` line passes everything after the interpreter path to `env` as a
**single** argument on Linux, so `env` looks for a literal program
named `node --enable-source-maps` and fails:

```console
$ ./shebang-test.mjs
env: 'node --enable-source-maps': No such file or directory
env: use -[v]S to pass options in shebang lines
```

pnpm masked this: it links `bin` entries through a generated shell
shim that re-reads and rebuilds the command itself, so the broken line
never reaches the kernel in this workspace. npm and yarn link `bin`
entries as **symlinks** and rely on the shebang directly, so a
consumer running `npm i -g @kurone-kito/sea-builder` or
`npx @kurone-kito/sea-builder` on Linux hits the failure — this is a
real published-package defect, not just a workspace quirk.

## Decision: `-S` form, not the runtime form

Changed all three shebangs to `#!/usr/bin/env -S node --enable-source-maps`
rather than `#!/usr/bin/env node` + `process.setSourceMapsEnabled(true)`:
keeps the flag at its declaration site instead of adding boilerplate to
three entry modules. Caveat: `-S` is a hard failure on any `env`
predating GNU coreutils 8.30 (2018) or the equivalent BSD/macOS `env`.
Accepted — CI runners (`ubuntu-latest`, `windows-latest`) and realistic
npm/npx consumers are well past that floor.

## Verification

CI cannot verify this fix: all matrix jobs run through pnpm's
`node_modules/.bin` shims, which is the exact masking mechanism this
issue describes, so a green CI matrix proves nothing about the
shebang. Verified locally instead, after `pnpm run build` (built bins
are emitted mode `0644`, so `chmod +x` is required first, same as a
package manager does at install time):

- `sea-builder/dist/builder.mjs --help` → prints the `Usage: sea-builder
  --targets=…` line (previously: the `env:` error above).
- `sea-builder/dist/cache.mjs --help` → runs its listr2 task output
  (previously: the same `env:` error).
- `example-cli/dist/index.mjs` → prints `Hello, world!` (previously:
  the same `env:` error).
- An injected throw in a running copy of `dist/builder.mjs` resolves
  its stack trace to a `src/builder.mts` source position, confirming
  `--enable-source-maps` is still active through `-S`.
- `pnpm run lint && pnpm run build && pnpm run test` all pass (58
  tests, including `example-cli/src/index.spec.mts`, which runs the
  built artifact).

Closes #58
