### PR TITLE
fix(root): stop CodeRabbit from auto-labeling issues

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,6 +1,9 @@
 chat:
   auto_reply: true
 early_access: true
+issue_enrichment:
+  labeling:
+    auto_apply_labels: false
 language: en
 reviews:
   auto_review:


### PR DESCRIPTION
## Summary

`coderabbitai[bot]` was re-adding the `roadmap` label to execution
children of the IDD adoption roadmap (#48, #49, #50) within seconds of
any body edit — silently routing them into roadmap-audit handling
instead of the normal claim path once the IDD import starts consuming
that label as `labels.roadmapLabelName`.

Reproduced live before writing this fix: re-submitting #48's body
unchanged (`gh issue edit --body-file`) triggered a fresh `roadmap`
label from the bot 6 seconds later. Removed it again before
proceeding.

## Change

Set `issue_enrichment.labeling.auto_apply_labels: false` in
`.coderabbit.yaml` — confirmed against CodeRabbit's published schema
(`storage.googleapis.com/coderabbit_public_assets/schema.v2.json`).

The schema's own default for this key is already `false`, so the
observed behavior implies a dashboard-level override outside this
repo's committed config; setting it explicitly here removes that
ambiguity regardless of what the dashboard says.

Chose option 1 from the issue (constrain CodeRabbit) over option 2
(namespace the IDD control labels in `.github/idd/config.json`)
because option 2 only becomes available once #49 lands.

## Verification

- `pnpm run lint` passes.
- Re-checked the current label state:
  `gh issue list --state open --json number,labels --jq '.[] | select([.labels[].name] | index("roadmap")) | .number'`
  returns only `#52` and `#64` (the two genuine roadmap nodes).

**Cannot be verified before merge**: CodeRabbit reads bot-level
repository config from the **default branch**, not from a pull
request's branch, so the acceptance criterion's reproduction test
(edit a non-roadmap issue, confirm the bot doesn't relabel it) can
only run after this lands on `main`. Will post that result as a
follow-up comment on #65 once merged, and reopen with a fallback fix
if it doesn't hold.

Refs #65 — left open intentionally: the acceptance criterion
(edit a non-roadmap issue post-merge, confirm no auto-label) hasn't
run yet. Will close #65 by hand once that check passes, per the
"Cannot be verified before merge" note above.

