### PR TITLE
fix(ci): add the version guard to the npmjs publish job

### DIFF
--- a/.github/workflows/common-release.yml
+++ b/.github/workflows/common-release.yml
@@ -37,10 +37,10 @@ jobs:
         name: Install the dependencies
         run: pnpm install --frozen-lockfile --prefer-offline
       - if: ${{ inputs.next == true }}
-        name: Check the whether the current version is prerelease
+        name: Check whether the current version is a prerelease
         run: pnpm run is:prerelease
       - if: ${{ inputs.next != true }}
-        name: Check the whether the current version is not prerelease
+        name: Check whether the current version is not a prerelease
         run: pnpm run is:release
       - name: Build the project explicitly. The workaround is provisional because the publish command does not perform topological sorting.
         run: pnpm run build
@@ -84,10 +84,10 @@ jobs:
         name: Install the dependencies
         run: pnpm install --frozen-lockfile --prefer-offline
       - if: ${{ inputs.next == true }}
-        name: Check the whether the current version is prerelease
+        name: Check whether the current version is a prerelease
         run: pnpm run is:prerelease
       - if: ${{ inputs.next != true }}
-        name: Check the whether the current version is not prerelease
+        name: Check whether the current version is not a prerelease
         run: pnpm run is:release
       - name: Build the project explicitly. The workaround is provisional because the publish command does not perform topological sorting.
         run: pnpm run build
@@ -131,10 +131,10 @@ jobs:
         name: Install the dependencies
         run: pnpm install --frozen-lockfile --prefer-offline
       - if: ${{ inputs.next == true }}
-        name: Check the whether the current version is prerelease
+        name: Check whether the current version is a prerelease
         run: pnpm run is:prerelease
       - if: ${{ inputs.next != true }}
-        name: Check the whether the current version is not prerelease
+        name: Check whether the current version is not a prerelease
         run: pnpm run is:release
       - name: Build the project explicitly. The workaround is provisional because the publish command does not perform topological sorting.
         run: pnpm run build

--- a/.github/workflows/common-release.yml
+++ b/.github/workflows/common-release.yml
@@ -36,6 +36,12 @@ jobs:
           HUSKY: 0
         name: Install the dependencies
         run: pnpm install --frozen-lockfile --prefer-offline
+      - if: ${{ inputs.next == true }}
+        name: Check the whether the current version is prerelease
+        run: pnpm run is:prerelease
+      - if: ${{ inputs.next != true }}
+        name: Check the whether the current version is not prerelease
+        run: pnpm run is:release
       - name: Build the project explicitly. The workaround is provisional because the publish command does not perform topological sorting.
         run: pnpm run build
       - env:
@@ -49,10 +55,10 @@ jobs:
           EOF
       - if: ${{ inputs.next != true }}
         name: Publish the packages
-        run: pnpm run publish --no-git-check
+        run: pnpm run publish
       - if: ${{ inputs.next == true }}
         name: Publish the packages as the alpha version
-        run: pnpm run publish:next --no-git-check
+        run: pnpm run publish:next
   build-and-deploy-to-github:
     name: Build and deploy to GitHub Packages
     permissions:
@@ -94,12 +100,12 @@ jobs:
           @kurone-kito:registry=https://npm.pkg.github.com/
           //npm.pkg.github.com/:_authToken=$GITHUB_TOKEN
           EOF
-      - if: ${{ !inputs.next }}
+      - if: ${{ inputs.next != true }}
         name: Publish the packages
-        run: pnpm run publish --no-git-check
-      - if: ${{ inputs.next }}
+        run: pnpm run publish
+      - if: ${{ inputs.next == true }}
         name: Publish the packages as the alpha version
-        run: pnpm run publish:next --no-git-check
+        run: pnpm run publish:next
   build-and-deploy-packages-to-release:
     if: ${{ github.event_name == 'release' }}
     name: Build and deploy the packages to the release


### PR DESCRIPTION
## Summary

`build-and-deploy-to-npmjs` — the job that publishes to the **public
npm registry** — was the only one of the three publishing jobs in
`common-release.yml` with no version guard. `build-and-deploy-to-github`
and `build-and-deploy-packages-to-release` both run `pnpm run
is:prerelease` / `pnpm run is:release` before publishing; the npmjs job
went straight from build to publish. Since npm does not allow
republishing a version, a prerelease accidentally published under the
`latest` dist-tag has to be deprecated and worked around rather than
undone.

## Changes

- Add the same version-guard steps `build-and-deploy-to-github` already
  uses to `build-and-deploy-to-npmjs`, before the build step: `pnpm run
  is:prerelease` under `inputs.next == true`, `pnpm run is:release`
  under `inputs.next != true`.
- Drop the stray `--no-git-check` argument (not a real pnpm flag — the
  correct spelling is `--no-git-checks`, and the root `publish` /
  `publish:next` scripts already pass it) from all four publish steps
  across both jobs, rather than doubling up on the flag.
- Align `build-and-deploy-to-github`'s publish-step conditions
  (`!inputs.next` / `inputs.next`) with the `== true` / `!= true` style
  used by every other conditional in the file, including its own
  version-guard steps two steps above.

## Verification

- `pnpm run is:release` exits `0` and `pnpm run is:prerelease` exits
  `1` on the current `0.21.0` tree, confirming the guard fires the
  right way for a non-prerelease version.
- `grep -c 'no-git-check\b' .github/workflows/common-release.yml`
  returns `0`; root `package.json`'s `publish` / `publish:next` scripts
  are unchanged (still carry `--no-git-checks`).
- `actionlint .github/workflows/common-release.yml` and a full
  repo-wide `actionlint` both exit `0`.
- `pnpm run lint` passes.

Closes #54
