### PR TITLE
chore(sea-builder): remove the unused, exact-pinned undici devDependency

### DIFF
--- a/packages/sea-builder/package.json
+++ b/packages/sea-builder/package.json
@@ -52,7 +52,6 @@
     "rimraf": "^6.0.1",
     "type-fest": "^5.0.1",
     "typescript": "~5.9.3",
-    "undici": "7.28.0",
     "vite": "^7.1.9",
     "vitest": "^4.1.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -178,9 +178,6 @@ importers:
       typescript:
         specifier: ~5.9.3
         version: 5.9.3
-      undici:
-        specifier: 7.28.0
-        version: 7.28.0
       vite:
         specifier: ^7.1.9
         version: 7.1.9(@types/node@24.6.2)(jiti@2.6.1)(yaml@2.8.1)
@@ -2671,10 +2668,6 @@ packages:
 
   undici-types@7.13.0:
     resolution: {integrity: sha512-Ov2Rr9Sx+fRgagJ5AX0qvItZG/JKKoBRAVITs1zk7IqZGTJUwgUr7qoYBpWwakpWilTZFM98rG/AFRocu10iIQ==}
-
-  undici@7.28.0:
-    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
-    engines: {node: '>=20.18.1'}
 
   unicorn-magic@0.1.0:
     resolution: {integrity: sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==}
@@ -5341,8 +5334,6 @@ snapshots:
   ufo@1.6.1: {}
 
   undici-types@7.13.0: {}
-
-  undici@7.28.0: {}
 
   unicorn-magic@0.1.0: {}
 


### PR DESCRIPTION
## Summary

`packages/sea-builder/package.json` declared `undici` as an
exact-pinned devDependency with nothing in the package importing it.

## Investigation (per the issue's step 1-2)

- `grep -rn undici packages/sea-builder/src` — no match. The package's
  only network call, `downloadArchive.mts`, uses the global `fetch`.
- `pnpm why undici --recursive` from the workspace root shows exactly
  one resolution path: `@kurone-kito/sea-builder`'s own
  `devDependencies` entry. Nothing else in the workspace resolves it
  transitively, and the lockfile's `undici@7.28.0: {}` entry has no
  dependents of its own — so the pin was not forcing a transitive
  resolution either.
- `git log -S '"undici"' -- packages/sea-builder/package.json` finds
  one commit, `feat(root,sea): implemented the utils functions`
  (2025-06-29), which bulk-added several dependencies while
  implementing utils; no comment or commit message explains why
  `undici` specifically was included, and it isn't referenced by any
  of the utils added in that same commit.

**Conclusion**: branch 1 from the issue applies — genuinely unused,
no stated reason found. Removed the direct dependency; no
`pnpm.overrides` entry was needed or added.

Note on versions: the issue's background section cites `undici@7.16.0`
and a still-open Dependabot bump from 2026-06-09; by the time this was
picked up, that Dependabot PR had already merged (current pin was
`7.28.0`, confirmed via `git log` on the file), so there is no stale
Dependabot PR left to close as superseded — the underlying
dead-dependency problem is unaffected by which version was pinned.

## Changes

- Removed the `undici` line from
  `packages/sea-builder/package.json`'s `devDependencies`.
- Refreshed `pnpm-lock.yaml` via `pnpm install --no-frozen-lockfile`.

## Verification

- `packages/sea-builder/package.json` no longer lists `undici`.
- `pnpm-lock.yaml` no longer contains an `undici` import for
  `packages/sea-builder` (the remaining `undici-types` entries are an
  unrelated transitive dependency of `@types/node`).
- `pnpm install --frozen-lockfile && pnpm run lint && pnpm run build
  && pnpm run test` all pass.

Closes #56
