### PR TITLE
fix(sea-builder,example-cli): stop devPreinstall from fetching pnpm dlx packages

### DIFF
--- a/packages/example-cli/package.json
+++ b/packages/example-cli/package.json
@@ -26,7 +26,7 @@
     "build:sea": "sea-builder --node=20 --targets=darwin-arm64,darwin-x64,linux-arm64,linux-x64,win-arm64,win-x64 example-cli",
     "clean": "rimraf -g \"*.tgz\" \"*.tsbuildinfo\" coverage dist LICENSE node_modules/.cache sea",
     "dev": "vite build --watch",
-    "devPreinstall": "pnpm dlx mkdirp dist && pnpm dlx shx head -n 1 src/index.mts > dist/index.mjs",
+    "devPreinstall": "node ../../scripts/createEntryStub.mjs src/index.mts dist/index.mjs",
     "prebuild": "cpy --flat ../../LICENSE .",
     "prebuild:sea": "pnpm run build",
     "prepack": "pnpm run clean && pnpm run build",

--- a/packages/sea-builder/package.json
+++ b/packages/sea-builder/package.json
@@ -29,9 +29,9 @@
     "build": "vite build",
     "clean": "rimraf -g \"*.tgz\" \"*.tsbuildinfo\" coverage dist LICENSE node_modules/.cache",
     "dev": "vite build --watch",
-    "devPreinstall": "pnpm dlx mkdirp dist && pnpm run \"/devPreinstall:.+/\"",
-    "devPreinstall:builder": "pnpm dlx shx head -n 1 src/builder.mts > dist/builder.mjs",
-    "devPreinstall:cache": "pnpm dlx shx head -n 1 src/cache.mts > dist/cache.mjs",
+    "devPreinstall": "pnpm run \"/devPreinstall:.+/\"",
+    "devPreinstall:builder": "node ../../scripts/createEntryStub.mjs src/builder.mts dist/builder.mjs",
+    "devPreinstall:cache": "node ../../scripts/createEntryStub.mjs src/cache.mts dist/cache.mjs",
     "prebuild": "cpy --flat ../../LICENSE .",
     "prepack": "pnpm run clean && pnpm run build",
     "test": "vitest run --coverage"

--- a/scripts/createEntryStub.mjs
+++ b/scripts/createEntryStub.mjs
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+
+import { mkdirSync, readFileSync, realpathSync, writeFileSync } from 'node:fs';
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const [, bin, src, dest] = process.argv;
+if (fileURLToPath(import.meta.url) !== realpathSync(bin)) {
+  throw new Error('This script cannot be imported.');
+}
+const [firstLine] = readFileSync(src, 'utf8').split(/\r?\n/);
+mkdirSync(dirname(dest), { recursive: true });
+writeFileSync(dest, `${firstLine}\n`);


### PR DESCRIPTION
## Summary

`devPreinstall` in `packages/example-cli` and `packages/sea-builder`
ran `pnpm dlx mkdirp` / `pnpm dlx shx head -n 1` on every install —
five unpinned, unreviewed registry resolutions purely to create a
directory and copy one line of a source file into a stub, with no
lockfile entry recording what actually runs, and a hard failure in any
offline/registry-restricted install.

## Changes

- Added `scripts/createEntryStub.mjs`: given a source file and a
  destination path, it creates the destination's directory (recursive,
  matching what `mkdirp` did) and writes the source's first line plus
  a trailing newline to it (matching what `shx head -n 1 ... >` did).
  No dependency, no shell built-ins — follows the existing
  `scripts/isPrerelease.mjs` convention (shebang, a same-file
  direct-invocation guard) and is invoked explicitly via `node`, not
  relied on as an executable, since `node <path>` behaves identically
  under both `cmd.exe` and POSIX shells while a bare shebang-executed
  path does not on Windows.
- `packages/example-cli`'s `devPreinstall` and
  `packages/sea-builder`'s `devPreinstall:builder` /
  `devPreinstall:cache` now call this script instead of `pnpm dlx`.
  `sea-builder`'s top-level `devPreinstall` no longer needs its own
  `pnpm dlx mkdirp dist &&` prefix, since each stub call creates its
  own destination directory.
- The stub contents and destinations are unchanged — only the
  mechanism that produces them changed, per the issue's scope.

## Verification

- `grep -rn 'pnpm dlx' --include=package.json .` (excluding
  `node_modules`) returns no match.
- `rm -rf packages/example-cli/dist packages/sea-builder/dist &&
  pnpm install` recreates all three stub files
  (`example-cli/dist/index.mjs`, `sea-builder/dist/builder.mjs`,
  `sea-builder/dist/cache.mjs`), each containing exactly its source
  file's first line (`#!/usr/bin/env -S node --enable-source-maps`).
  The install log shows no `pnpm dlx` resolution step, where the
  previous behavior always printed one.
- `pnpm install --frozen-lockfile` still succeeds (nothing about the
  lockfile changed — `mkdirp`/`shx` were never recorded in it, which
  was the point of the issue).
- `pnpm run lint && pnpm run build && pnpm run test` all pass.

Closes #61
