### PR TITLE
fix(ci): pin third-party github actions to commit shas

### DIFF
--- a/.github/workflows/common-release.yml
+++ b/.github/workflows/common-release.yml
@@ -21,13 +21,13 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Stages the pushed branch
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Setup the pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           run_install: false
       - name: Prepare the Node.js environment
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           cache: pnpm
           check-latest: true
@@ -68,13 +68,13 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Stages the pushed branch
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Setup the pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           run_install: false
       - name: Prepare the Node.js environment
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           cache: pnpm
           check-latest: true
@@ -115,13 +115,13 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Stages the pushed branch
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Setup the pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           run_install: false
       - name: Prepare the Node.js environment
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           cache: pnpm
           check-latest: true
@@ -141,7 +141,7 @@ jobs:
       - name: pack the packages
         run: pnpm --filter "!*builder-config" -r pack
       - name: Uploading assets to the release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           files: '*.tgz'
   build-and-deploy-sea-to-release:
@@ -153,13 +153,13 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Stages the pushed branch
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Setup the pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           run_install: false
       - name: Prepare the Node.js environment
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           cache: pnpm
           check-latest: true
@@ -177,6 +177,6 @@ jobs:
             zip -9 "${bin}.zip" "$bin"
           done
       - name: Uploading assets to the release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           files: 'packages/example-cli/sea/*.zip'

--- a/.github/workflows/push-feature.yml
+++ b/.github/workflows/push-feature.yml
@@ -29,13 +29,13 @@ jobs:
           git config --global core.autocrlf false
           git config --global core.eol lf
       - name: Stages the pushed branch
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Setup the pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           run_install: false
       - name: Prepare the Node.js version ${{ matrix.node-version }} environment
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           cache: pnpm
           check-latest: true

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -20,6 +20,6 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@v6
+      - uses: release-drafter/release-drafter@6a93d829887aa2e0748befe2e808c66c0ec6e4c7 # v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -9,7 +9,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v10
+      - uses: actions/stale@1e223db275d687790206a7acac4d1a11bd6fe629 # v10
         with:
           days-before-close: 14
           days-before-stale: 60


### PR DESCRIPTION
## Summary

Every `uses:` reference in `.github/workflows/**` pointed at a floating
major tag. `common-release.yml` — which holds `secrets.NPM_TOKEN`,
writes it to `~/.npmrc`, and runs with `contents: write` and
`packages: write` — is the highest-value target: a repointed tag on any
action running in that job would execute with the publish token in the
environment.

## Changes

Replaced every `uses: <owner>/<repo>@<tag>` with
`uses: <owner>/<repo>@<full-40-char-sha> # <tag>`, resolved from each
tag currently in use — no action version changes in this PR:

| Action | Tag | Resolved commit SHA |
| --- | --- | --- |
| `actions/checkout` | `v7` | `3d3c42e5aac5ba805825da76410c181273ba90b1` |
| `pnpm/action-setup` | `v4` | `b906affcce14559ad1aafd4ab0e942779e9f58b1` |
| `actions/setup-node` | `v5` | `a0853c24544627f65ddf259abe73b1d18a591444` |
| `softprops/action-gh-release` | `v2` | `3bb12739c298aeb8a4eeaf626c5b8d85266b0e65` |
| `release-drafter/release-drafter` | `v6` | `6a93d829887aa2e0748befe2e808c66c0ec6e4c7` |
| `actions/stale` | `v10` | `1e223db275d687790206a7acac4d1a11bd6fe629` |

Resolved via `gh api repos/<owner>/<repo>/git/ref/tags/<tag>` for each
— two of the six (`pnpm/action-setup`, `release-drafter/release-drafter`)
are **annotated** tags, so the ref API returns the tag object's own SHA
rather than the commit; those two were dereferenced one level further
via `gh api repos/<owner>/<repo>/git/tags/<tag-object-sha>` to reach
the actual commit SHA pinned above. The trailing `# vX` comment is kept
on every line for Dependabot (which already tracks the
`github-actions` ecosystem in this repo and understands SHA pins
carried with a version comment) and for human readability.

The issue's background table cites `actions/checkout@v5` /
`actions/setup-node@v5`; by the time this was picked up, `checkout`
had already been bumped to `v7` on `main` (Dependabot), so this pins
the versions actually in use today rather than the ones quoted when
the issue was written.

## Verification

- `grep -rn 'uses: .*@v[0-9]' .github/workflows/` returns no match.
- Every pinned line carries its trailing `# vX` comment.
- `actionlint` (repo-wide, and per-file) exits `0`.
- `pnpm run lint` passes.
- CI is green on this PR's own branch (the SHAs above are the exact
  commits the pre-pin tags resolved to, so this is a no-behavior-change
  mechanical pin, not a version bump).

Closes #55
