### PR TITLE
chore(root): bump idd-skill pin from 0.4.0-snapshot to v0.6.0

### DIFF
--- a/.github/idd/config.json
+++ b/.github/idd/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://kurone-kito.github.io/idd-skill/schemas/policy.schema.json",
-  "iddVersion": "0.4.0",
+  "iddVersion": "0.6.0",
   "markerPrefix": "builder-config",
   "mergePolicy": "fully_autonomous_merge",
   "reviewPolicy": "copilot-advisory",

--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -75,11 +75,11 @@ the npm registry**; its default dependency spec is a moving
 to a reviewed commit archive for reproducibility:
 
 ```text
-https://codeload.github.com/kurone-kito/idd-skill/tar.gz/bc811500653a3bd504d34e4a08ad00a18eb72a9e
+https://codeload.github.com/kurone-kito/idd-skill/tar.gz/0a9c90dc277e05e0d7d96f1b09d79ff668860cc6
 ```
 
-(idd-skill commit `bc81150`, `@kurone-kito/idd-skill@0.4.0`.) Bump this
-pin deliberately (re-run
+(idd-skill commit `0a9c90d`, tag `v0.6.0`, `@kurone-kito/idd-skill@0.6.0`.)
+Bump this pin deliberately (re-run
 `idd-helper-bundle-manifest --profile package-manager --package-spec <new-pin>`
 from a newer idd-skill clone) rather than letting it drift to `main`.
 

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "@kurone-kito/commitlint-config": "^0.21.0",
     "@kurone-kito/cspell-config": "^0.21.0",
     "@kurone-kito/example-cli": "workspace:^",
-    "@kurone-kito/idd-skill": "https://codeload.github.com/kurone-kito/idd-skill/tar.gz/bc811500653a3bd504d34e4a08ad00a18eb72a9e",
+    "@kurone-kito/idd-skill": "https://codeload.github.com/kurone-kito/idd-skill/tar.gz/0a9c90dc277e05e0d7d96f1b09d79ff668860cc6",
     "@kurone-kito/lint-staged-config": "^0.21.0",
     "@kurone-kito/markdownlint-config": "^0.22.0",
     "@types/semver": "^7.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,8 +62,8 @@ importers:
         specifier: workspace:^
         version: link:packages/example-cli
       '@kurone-kito/idd-skill':
-        specifier: https://codeload.github.com/kurone-kito/idd-skill/tar.gz/bc811500653a3bd504d34e4a08ad00a18eb72a9e
-        version: https://codeload.github.com/kurone-kito/idd-skill/tar.gz/bc811500653a3bd504d34e4a08ad00a18eb72a9e
+        specifier: https://codeload.github.com/kurone-kito/idd-skill/tar.gz/0a9c90dc277e05e0d7d96f1b09d79ff668860cc6
+        version: https://codeload.github.com/kurone-kito/idd-skill/tar.gz/0a9c90dc277e05e0d7d96f1b09d79ff668860cc6
       '@kurone-kito/lint-staged-config':
         specifier: ^0.21.0
         version: 0.21.0(cspell@10.0.1)(lint-staged@17.2.0)
@@ -878,9 +878,9 @@ packages:
       cspell:
         optional: true
 
-  '@kurone-kito/idd-skill@https://codeload.github.com/kurone-kito/idd-skill/tar.gz/bc811500653a3bd504d34e4a08ad00a18eb72a9e':
-    resolution: {gitHosted: true, integrity: sha512-vVVE8mW8FLp9iuDI4w0k/tFwqwkcnexvGmB/caoCWj8WCH3G5UpZRc6A5ORSAM1bKJFKhVhmoMF+USm17+R9Kw==, tarball: https://codeload.github.com/kurone-kito/idd-skill/tar.gz/bc811500653a3bd504d34e4a08ad00a18eb72a9e}
-    version: 0.4.0
+  '@kurone-kito/idd-skill@https://codeload.github.com/kurone-kito/idd-skill/tar.gz/0a9c90dc277e05e0d7d96f1b09d79ff668860cc6':
+    resolution: {gitHosted: true, integrity: sha512-qyywo8fuUnEW95BimFE77E85NscLot0/hug5fs60b4wyeSyT5yqp98BX+ZZZBS87m//MT+uZ+vLAbPAE45F17w==, tarball: https://codeload.github.com/kurone-kito/idd-skill/tar.gz/0a9c90dc277e05e0d7d96f1b09d79ff668860cc6}
+    version: 0.6.0
     engines: {node: ^22.22.2 || >=24.2.0}
     hasBin: true
 
@@ -3261,7 +3261,7 @@ snapshots:
     optionalDependencies:
       cspell: 10.0.1
 
-  '@kurone-kito/idd-skill@https://codeload.github.com/kurone-kito/idd-skill/tar.gz/bc811500653a3bd504d34e4a08ad00a18eb72a9e': {}
+  '@kurone-kito/idd-skill@https://codeload.github.com/kurone-kito/idd-skill/tar.gz/0a9c90dc277e05e0d7d96f1b09d79ff668860cc6': {}
 
   '@kurone-kito/lint-staged-config@0.21.0(cspell@10.0.1)(lint-staged@17.2.0)':
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,5 @@
 allowBuilds:
-  '@kurone-kito/idd-skill@https://codeload.github.com/kurone-kito/idd-skill/tar.gz/bc811500653a3bd504d34e4a08ad00a18eb72a9e': true
+  '@kurone-kito/idd-skill@https://codeload.github.com/kurone-kito/idd-skill/tar.gz/0a9c90dc277e05e0d7d96f1b09d79ff668860cc6': true
   esbuild: true
 configDependencies:
   '@pnpm/plugin-types-fixer': 0.1.0+sha512-bLww63gRHi7siYTqFJb5qNdcXadU0jv20Et6z5AryMZ7FlLolbEJOrXLpg8+amQZNHHNW1dfFUBGVw/9ezQbFg==


### PR DESCRIPTION
## Summary

- Bump the pinned `@kurone-kito/idd-skill` helper devDependency from
  commit `bc81150` (an unreleased `main` snapshot recorded as
  `iddVersion: "0.4.0"`) to the current upstream release, tag `v0.6.0`
  (commit `0a9c90d`).
- Update `.github/idd/config.json`'s `iddVersion` to `"0.6.0"` and
  `docs/idd-policy.md`'s Helper Runtime Profile section to name the new
  pinned commit/version.
- Regenerate `pnpm-lock.yaml` and `pnpm-workspace.yaml`'s `allowBuilds`
  key for the new tarball URL (the git-hosted dependency's build-script
  approval is keyed by the exact pinned URL, so the old key had to be
  swapped for the new one, not just added alongside it).

This is the first child of roadmap #97 (idd-resync-2026-08) — the
highest-priority track others read the pinned commit/changelog from.
File-set reconciliation and new policy schema keys are tracked
separately (#94, #95) and out of scope here.

Closes #92

## Test plan

- [x] `pnpm install --frozen-lockfile` resolves the new pinned tarball
- [x] `pnpm exec idd-doctor` passes (0 errors; only pre-existing
      warnings: post-merge cleanup backlog, release-tag drift, #51's
      branch protection)
- [x] `pnpm run lint`
- [x] `pnpm run build`
- [x] `pnpm run test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the project’s internal development tooling to version 0.6.0.
  - Refreshed the associated tooling references and verification pins to ensure consistent builds and checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->