### PR TITLE
feat(root): add advisory-bot and CI-gate policy schema keys

### DIFF
--- a/.github/idd/config.json
+++ b/.github/idd/config.json
@@ -27,7 +27,7 @@
   "orphanFirstPolicy": "none",
   "advisoryWait": {
     "convergenceScope": "all-prs",
-    "primaryBotLogin": "copilot-pull-request-reviewer[bot]",
+    "primaryBotLogin": "copilot",
     "secondaryBotLogin": "coderabbitai[bot]",
     "exemptBotAuthoredPrs": true
   },

--- a/.github/idd/config.json
+++ b/.github/idd/config.json
@@ -35,6 +35,9 @@
     "coderabbitai[bot]",
     "chatgpt-codex-connector[bot]"
   ],
+  "ciGate": {
+    "trustSourcePinnedRequiredChecks": false
+  },
   "autopilotSuitability": {
     "floor": 3
   },

--- a/.github/idd/config.json
+++ b/.github/idd/config.json
@@ -28,7 +28,6 @@
   "advisoryWait": {
     "convergenceScope": "all-prs",
     "primaryBotLogin": "copilot",
-    "secondaryBotLogin": "coderabbitai[bot]",
     "exemptBotAuthoredPrs": true
   },
   "advisoryBotLogins": [

--- a/.github/idd/config.json
+++ b/.github/idd/config.json
@@ -26,8 +26,16 @@
   "issueScope": "roadmap-first",
   "orphanFirstPolicy": "none",
   "advisoryWait": {
-    "convergenceScope": "all-prs"
+    "convergenceScope": "all-prs",
+    "primaryBotLogin": "copilot-pull-request-reviewer[bot]",
+    "secondaryBotLogin": "coderabbitai[bot]",
+    "exemptBotAuthoredPrs": true
   },
+  "advisoryBotLogins": [
+    "copilot-pull-request-reviewer[bot]",
+    "coderabbitai[bot]",
+    "chatgpt-codex-connector[bot]"
+  ],
   "autopilotSuitability": {
     "floor": 3
   },

--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -54,7 +54,10 @@ repository override.
 **Scope**: `advisoryWait.convergenceScope` = `all-prs` (distributed
 default). Kept rather than switched to `idd-claimed`, so advisory
 convergence applies to every PR, not only verified IDD-owned PRs — this
-repository does not want to exempt non-IDD PRs from convergence.
+repository does not want to exempt non-IDD PRs from convergence, other
+than the narrow `exemptBotAuthoredPrs` carve-out below (a genuinely
+`Bot`-typed author with no claim history, such as Dependabot — not a
+blanket non-IDD-PR exemption).
 
 ## Advisory-Bot Policy
 

--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -56,6 +56,48 @@ default). Kept rather than switched to `idd-claimed`, so advisory
 convergence applies to every PR, not only verified IDD-owned PRs — this
 repository does not want to exempt non-IDD PRs from convergence.
 
+## Advisory-Bot Policy
+
+- **`advisoryWait.primaryBotLogin`**: `copilot-pull-request-reviewer[bot]`
+  — this repository's `reviewPolicy` is `copilot-advisory`, so the
+  advisory-wait gate's primary signal is GitHub Copilot's PR-review bot.
+  The exact login (including the `[bot]` suffix) was confirmed against a
+  live `gh api repos/{owner}/{repo}/pulls/{n}/reviews` read on a recent
+  PR rather than assumed.
+- **`advisoryWait.secondaryBotLogin`**: `coderabbitai[bot]` — CodeRabbit
+  already reviews every PR in this repository. Confirmed via a live
+  `gh api` timeline-event read (`sender.login` + `type: Bot`); the
+  similarly-named `coderabbitai` `Organization` actor seen in the same
+  event stream is a distinct identity and not the review bot.
+- **`advisoryBotLogins`**: `["copilot-pull-request-reviewer[bot]",
+  "coderabbitai[bot]", "chatgpt-codex-connector[bot]"]` — the same two
+  bots, plus `chatgpt-codex-connector[bot]`, a third review bot first
+  observed on PR #99 (issue #94) that was not previously configured
+  anywhere. Listing it here lets its post-disposition acknowledgement
+  comments classify as structurally ack-only going forward instead of
+  counting as fresh review activity.
+- **`advisoryWait.exemptBotAuthoredPrs`**: `true` (opt-in, non-default)
+  — this repository has a long history of Dependabot-authored PRs (see
+  PR #28 through #86 among others) that never carry an IDD claim.
+  Enabled so those PRs are classified `not_applicable` under
+  `convergenceScope: all-prs` instead of being forced through the
+  advisory-convergence gate meant for claimed IDD work.
+
+## External CI-Check Trust
+
+**`ciGate.trustSourcePinnedRequiredChecks`**: left unset (default
+`false`), not enabled. This flag only matters once a required-check
+Ruleset entry is itself source-pinned (an optional choice in GitHub's
+Ruleset UI, picking a specific reporting App from a dropdown rather than
+a bare check-name match). Issue #51 — which will register
+`idd-advisory-convergence` as a required status check — describes only
+the standard check-name registration flow, with no mention of pinning a
+specific integration source, and has not run yet, so there is no live
+ruleset entry to inspect and confirm either way. Revisit this decision
+once #51 actually executes and the resulting entry can be inspected via
+`gh api repos/{owner}/{repo}/rules/branches/main`; enable only if that
+entry turns out to be source-pinned.
+
 ## Credential Scope
 
 **Worker credentials**: repository write access for issue/PR/branch

--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -74,16 +74,30 @@ repository does not want to exempt non-IDD PRs from convergence.
   set to) `copilot`; setting it to the REST form instead would leave
   `--add-reviewer`/`--remove-reviewer` targeting an identity `gh` cannot
   resolve via GraphQL.
-- **`advisoryWait.secondaryBotLogin`**: `coderabbitai[bot]` — CodeRabbit
-  already reviews every PR in this repository. Confirmed via a live
-  `gh api` timeline-event read (`sender.login` + `type: Bot`); the
-  similarly-named `coderabbitai` `Organization` actor seen in the same
-  event stream is a distinct identity and not the review bot.
+- **`advisoryWait.secondaryBotLogin`**: left unset. CodeRabbit was
+  evaluated (its bot login is `coderabbitai[bot]`, confirmed via a live
+  `gh api` timeline-event read — `sender.login` + `type: Bot`,
+  distinguishing it from the separate `coderabbitai` `Organization`
+  actor) but is **not requestable** the way this field requires: it
+  runs as an installed GitHub App with no user-resolvable login, so
+  `gh pr edit --add-reviewer "@coderabbitai[bot]"` fails outright
+  (`Could not resolve user`) and the REST `requested_reviewers`
+  fallback silently no-ops (both verified empirically against a live
+  PR in this repository) — neither path posts the `review_requested`
+  timeline event the once-per-HEAD guard needs. Configuring it anyway
+  would leave `secondaryRequestNeeded` permanently true, causing
+  repeated failed/no-op requests during primary-bot-stall recovery. Per
+  the schema, omitting this field disables the non-gating secondary
+  supplement entirely — CodeRabbit still contributes as ordinary
+  advisory input via its own automatic per-push reviews, just not
+  through this on-demand request path.
 - **`advisoryBotLogins`**: `["copilot-pull-request-reviewer[bot]",
-  "coderabbitai[bot]", "chatgpt-codex-connector[bot]"]` — the same two
-  bots, plus `chatgpt-codex-connector[bot]`, a third review bot first
-  observed on PR #99 (issue #94) that was not previously configured
-  anywhere. Listing it here lets its post-disposition acknowledgement
+  "coderabbitai[bot]", "chatgpt-codex-connector[bot]"]` — the REST
+  review-author identities these bots' comments/reviews actually carry
+  (a separate concern from requestability above), including
+  `chatgpt-codex-connector[bot]`, a third review bot first observed on
+  PR #99 (issue #94) that was not previously configured anywhere.
+  Listing all three here lets their post-disposition acknowledgement
   comments classify as structurally ack-only going forward instead of
   counting as fresh review activity.
 - **`advisoryWait.exemptBotAuthoredPrs`**: `true` (opt-in, non-default)

--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -58,12 +58,21 @@ repository does not want to exempt non-IDD PRs from convergence.
 
 ## Advisory-Bot Policy
 
-- **`advisoryWait.primaryBotLogin`**: `copilot-pull-request-reviewer[bot]`
-  — this repository's `reviewPolicy` is `copilot-advisory`, so the
-  advisory-wait gate's primary signal is GitHub Copilot's PR-review bot.
-  The exact login (including the `[bot]` suffix) was confirmed against a
-  live `gh api repos/{owner}/{repo}/pulls/{n}/reviews` read on a recent
-  PR rather than assumed.
+- **`advisoryWait.primaryBotLogin`**: `copilot` — this repository's
+  `reviewPolicy` is `copilot-advisory`, so the advisory-wait gate's
+  primary signal is GitHub Copilot's PR-review bot. This is the
+  GraphQL/requestable login `gh pr edit --add-reviewer`/`--remove-reviewer`
+  resolve, and matches idd-skill's own distributed default (explicit
+  here for self-documentation rather than left implicit). It is
+  deliberately **not** `copilot-pull-request-reviewer[bot]` — the
+  distinct REST identity that appears as the review author in
+  `gh api repos/{owner}/{repo}/pulls/{n}/reviews` and as the entry in
+  `advisoryBotLogins` below. idd-skill resolves both forms
+  automatically for the default Copilot bot (`EXACT_COPILOT_REVIEWER_LOGINS`
+  in `protocol-helpers.mts`) only when `primaryBotLogin` is left at (or
+  set to) `copilot`; setting it to the REST form instead would leave
+  `--add-reviewer`/`--remove-reviewer` targeting an identity `gh` cannot
+  resolve via GraphQL.
 - **`advisoryWait.secondaryBotLogin`**: `coderabbitai[bot]` — CodeRabbit
   already reviews every PR in this repository. Confirmed via a live
   `gh api` timeline-event read (`sender.login` + `type: Bot`); the

--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -60,11 +60,12 @@ repository does not want to exempt non-IDD PRs from convergence.
 
 - **`advisoryWait.primaryBotLogin`**: `copilot` — this repository's
   `reviewPolicy` is `copilot-advisory`, so the advisory-wait gate's
-  primary signal is GitHub Copilot's PR-review bot. This is the
-  GraphQL/requestable login `gh pr edit --add-reviewer`/`--remove-reviewer`
-  resolves, and matches idd-skill's own distributed default (explicit
-  here for self-documentation rather than left implicit). It is
-  deliberately **not** `copilot-pull-request-reviewer[bot]` — the
+  primary signal is GitHub Copilot's PR-review bot. `gh pr edit
+  --add-reviewer`/`--remove-reviewer` resolve this login via GraphQL
+  when requesting or removing a review; it matches idd-skill's own
+  distributed default (explicit here for self-documentation rather
+  than left implicit). It is deliberately
+  **not** `copilot-pull-request-reviewer[bot]` — the
   distinct REST identity that appears as the review author in
   `gh api repos/{owner}/{repo}/pulls/{n}/reviews` and as the entry in
   `advisoryBotLogins` below. idd-skill resolves both forms

--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -109,8 +109,11 @@ repository does not want to exempt non-IDD PRs from convergence.
 
 ## External CI-Check Trust
 
-**`ciGate.trustSourcePinnedRequiredChecks`**: left unset (default
-`false`), not enabled. This flag only matters once a required-check
+**`ciGate.trustSourcePinnedRequiredChecks`**: explicitly `false`
+(matching the schema default, recorded rather than left implicit so
+the decision stays stable and self-documenting against a future
+upstream default change), not enabled. This flag only matters once a
+required-check
 Ruleset entry is itself source-pinned (an optional choice in GitHub's
 Ruleset UI, picking a specific reporting App from a dropdown rather than
 a bare check-name match). Issue #51 — which will register

--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -62,7 +62,7 @@ repository does not want to exempt non-IDD PRs from convergence.
   `reviewPolicy` is `copilot-advisory`, so the advisory-wait gate's
   primary signal is GitHub Copilot's PR-review bot. This is the
   GraphQL/requestable login `gh pr edit --add-reviewer`/`--remove-reviewer`
-  resolve, and matches idd-skill's own distributed default (explicit
+  resolves, and matches idd-skill's own distributed default (explicit
   here for self-documentation rather than left implicit). It is
   deliberately **not** `copilot-pull-request-reviewer[bot]` — the
   distinct REST identity that appears as the review author in


### PR DESCRIPTION
## Summary

Adds the `.github/idd/config.json` policy keys upstream `idd-skill` introduced in `v0.5.0`/`v0.6.0` for advisory-bot identification and bot-authored-PR exemption, per issue #95 (Track3 of roadmap #97, idd-resync-2026-08):

- `advisoryWait.primaryBotLogin: "copilot"` — this repository's `reviewPolicy` is already `copilot-advisory`. This is the GraphQL/requestable login `gh pr edit --add-reviewer`/`--remove-reviewer` resolve against, and matches idd-skill's own distributed default (explicit here for self-documentation). **Not** the REST review-author identity `copilot-pull-request-reviewer[bot]` — a Copilot review-triage finding on this PR caught an earlier draft that conflated the two; fixed and verified against idd-skill's own source (`protocol-helpers.mts`, `advisory-wait-policy.mts`).
- `advisoryWait.secondaryBotLogin`: **left unset**. CodeRabbit was the natural candidate, but a `chatgpt-codex-connector[bot]` review-triage finding caught that CodeRabbit is not actually requestable — empirically verified against this live PR: `gh pr edit --add-reviewer "@coderabbitai[bot]"` fails outright, and the REST `requested_reviewers` fallback silently no-ops. Configuring it would have left the advisory-wait gate's `secondaryRequestNeeded` permanently true. CodeRabbit still contributes as ordinary advisory input via its own automatic per-push reviews.
- `advisoryBotLogins` (top-level, per the schema — not nested under `advisoryWait`): `copilot-pull-request-reviewer[bot]`, `coderabbitai[bot]`, and `chatgpt-codex-connector[bot]` — the REST review-author identities (a separate, unaffected concern from requestability above), including a third bot first observed on PR #99 (issue #94), not previously configured anywhere.
- `advisoryWait.exemptBotAuthoredPrs: true` — this repository has a long history of unclaimed Dependabot PRs (#28-#86 among others); exempts genuinely `Bot`-typed authors with no claim history from the advisory-convergence gate.
- `ciGate.trustSourcePinnedRequiredChecks`: explicitly `false` (matching the schema default, recorded rather than left implicit so the decision stays stable and self-documenting). This only matters once a required-check Ruleset entry is itself source-pinned to a specific GitHub App — issue #51 (which will register `idd-advisory-convergence` as a required check) describes only the standard check-name flow with no mention of source-pinning, and hasn't run yet, so there's no live entry to confirm either way. Documented as a deferred decision to revisit once #51 executes.

`docs/idd-policy.md` gets two new sections ("Advisory-Bot Policy", "External CI-Check Trust") documenting each field's chosen value and rationale, following the file's existing per-field pattern.

A C1 critique subagent independently verified the initial draft: schema key paths/types are correct (`advisoryBotLogins` at top level was the specific risk called out and confirmed correct), JSON is syntactically clean with no duplicate keys, and the `exemptBotAuthoredPrs` exemption is gated on GitHub's actual `Bot` account type (not a login/display-name match), so a human-controlled account cannot slip through it regardless of name. Two subsequent review-triage findings (Copilot: `primaryBotLogin` GraphQL-vs-REST confusion; codex-connector: `secondaryBotLogin`'s requestability) were both verified true and fixed before this PR merges.

Closes #95

## Test plan

- [x] `pnpm exec idd-doctor` passes (0 errors; `.github/idd/config.json validates against policy.schema.json`; only pre-existing warnings: post-merge cleanup backlog, release-tag drift, #51's branch protection)
- [x] `pnpm run lint`
- [x] `pnpm run build`
- [x] `pnpm run test`
- [x] All bot logins verified via live `gh api` reads, not guessed
- [x] `primaryBotLogin`'s GraphQL-vs-REST distinction verified against idd-skill's own source
- [x] `secondaryBotLogin`'s requestability (or lack thereof) verified empirically against this live PR (`gh pr edit --add-reviewer`, REST `requested_reviewers` fallback)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configuration for primary and secondary advisory bots.
  * Bot-authored pull requests are now exempt from advisory waiting requirements.
  * Registered Copilot, CodeRabbit, and ChatGPT Codex as advisory bots.

* **Documentation**
  * Clarified advisory-policy scope and bot behavior.
  * Documented external CI-check trust settings, including the temporary disabling of source-pinned required-check trust.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

