### PR TITLE
ci(root): redesign idd-advisory-convergence gate around upstream v0.6.0, reconcile idd-doctor.yml, add post-merge-cleanup.yml

### DIFF
--- a/.github/workflows/idd-doctor.yml
+++ b/.github/workflows/idd-doctor.yml
@@ -1,4 +1,7 @@
 name: IDD doctor health gate
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
 on:
   pull_request:
 permissions:
@@ -15,6 +18,10 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ github.sha }} # detached HEAD keeps the worktree check inert
+          # Full history and tags: the default fetch-depth: 1 shallow
+          # checkout hides tag refs, so idd-doctor's release-tag-drift
+          # check (`git describe --tags`) silently skips every run.
+          fetch-depth: 0
           persist-credentials: false
       - name: Setup the pnpm
         uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4

--- a/.github/workflows/post-merge-cleanup.yml
+++ b/.github/workflows/post-merge-cleanup.yml
@@ -1,0 +1,194 @@
+# Trust model: this workflow triggers on `pull_request_target`, which runs
+# with base-repository permissions and secrets even for a fork PR. That is
+# safe here only because all of the following hold, and any future edit to
+# this file must preserve them:
+#   - No unreviewed PR-head content is ever checked out: the checkout step
+#     below carries no `ref:` override, so it resolves to the
+#     `pull_request_target` default -- the base branch's tip at event time,
+#     which (because the job only proceeds when `merged == true`) already
+#     includes this PR's own merge commit. It is never the PR's own head SHA.
+#   - No PR-head code, workflow, or action is ever executed: the cleanup
+#     invocation below runs `pnpm exec idd-audit-pr-cleanup`, which resolves
+#     against this repository's own already-reviewed, already-merged
+#     `pnpm-lock.yaml`, not PR-head content.
+#   - The `pr_number` value (a `workflow_dispatch` number input, not
+#     strictly enforced as numeric for direct API dispatches) is passed
+#     through `env:` and referenced as a quoted shell variable, never
+#     interpolated directly into a `run:` script.
+#   - The `cleanup` job only runs when `github.event.pull_request.merged ==
+#     true`, or via an explicit, human-triggered `workflow_dispatch` --
+#     never against an open or unmerged pull request.
+#   - `permissions:` stays least-privilege: `contents: read`, `issues:
+#     write`, `pull-requests: write` -- no `contents: write` and no
+#     elevated or secret-bearing scopes.
+# If a future change adds a `ref:` override on the checkout step, downloads
+# or executes PR-head content, widens `permissions:`, or removes the
+# merged-only guard, re-review this trust model before merging that change.
+#
+# Server-side fallback for the agent's own F4 cleanup step
+# (idd-merge.instructions.md): the agent's local F4 run stays the primary,
+# mandatory path, but a session that exits at the F4/F5 boundary before
+# posting cleanup evidence (or one that skipped F4 outright) would
+# otherwise leave a merged PR's stale review comments never minimized.
+# This workflow re-runs the same `idd-audit-pr-cleanup`
+# helper unconditionally after every merge, so cleanup coverage does not
+# depend on any one session completing it.
+name: Post-merge cleanup
+on:
+  pull_request_target:
+    types:
+      - closed
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: PR number to clean up
+        required: true
+        type: number
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+concurrency:
+  # cancel-in-progress stays false, unlike the sibling read-only
+  # idd-advisory-convergence gate: this workflow mutates GitHub state
+  # (minimizes comments, posts an evidence comment), and cancelling it
+  # mid-mutation could leave a partially-applied cleanup with no evidence
+  # record. Let an in-flight run finish; a second trigger for the same PR
+  # simply queues.
+  group: post-merge-cleanup-${{ github.event.pull_request.number || github.event.inputs.pr_number }}
+  cancel-in-progress: false
+jobs:
+  cleanup:
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Stages the merged base branch
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - name: Setup the pnpm
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+        with:
+          run_install: false
+      - name: Prepare the Node.js environment
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          cache: pnpm
+          check-latest: true
+          node-version-file: .node-version
+      - name: Install the dependencies
+        run: pnpm install --frozen-lockfile --prefer-offline
+      - name: Run F4 cleanup (server-side fallback)
+        id: cleanup
+        env:
+          GH_TOKEN: ${{ github.token }}
+          # workflow_dispatch's `pr_number` input is `type: number` in the
+          # UI, but that constraint is not strictly enforced for direct API
+          # dispatches, so route it through env: and reference it as a
+          # quoted shell variable rather than interpolating the `${{ }}`
+          # expression directly into the run: script.
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.inputs.pr_number }}
+        run: |
+          set +e
+          JSON=$(pnpm exec idd-audit-pr-cleanup --pr "$PR_NUMBER" --apply --skip-claim-check --format json 2>cleanup-stderr.log)
+          HELPER_EXIT=$?
+          set -e
+          # Prefer the helper's JSON report when it is parseable, even on a
+          # non-zero exit: the helper writes the report then exits 1 when
+          # any candidate failed to minimize, so the report is still
+          # authoritative for what actually happened.
+          PARSED_STATUS=""
+          if [ -n "$JSON" ]; then
+            PARSED_STATUS=$(printf '%s' "$JSON" | jq -r '.status // ""' 2>/dev/null || echo "")
+          fi
+          if [ -n "$PARSED_STATUS" ]; then
+            STATUS="$PARSED_STATUS"
+            APPLIED=$(printf '%s' "$JSON" | jq -r '.summary.applied // 0')
+            FAILED=$(printf '%s' "$JSON" | jq -r '.summary.failed // 0')
+            SKIPPED=$(printf '%s' "$JSON" | jq -r '.summary.skipped // 0')
+            BLOCKED=$(printf '%s' "$JSON" | jq -r '.summary["viewer-cannot-minimize"] // 0')
+            if [ "$HELPER_EXIT" -ne 0 ]; then
+              echo "::warning::idd-audit-pr-cleanup exited $HELPER_EXIT but emitted a valid JSON report; using helper status \"$STATUS\""
+            fi
+          else
+            echo "::warning::idd-audit-pr-cleanup exited $HELPER_EXIT with no parseable JSON; posting helper-error evidence"
+            cat cleanup-stderr.log || true
+            STATUS="helper-error"
+            APPLIED=0
+            FAILED=0
+            SKIPPED=0
+            BLOCKED=0
+          fi
+          {
+            echo "pr_number=$PR_NUMBER"
+            echo "status=$STATUS"
+            echo "applied=$APPLIED"
+            echo "failed=$FAILED"
+            echo "skipped=$SKIPPED"
+            echo "blocked=$BLOCKED"
+          } >> "$GITHUB_OUTPUT"
+      - name: Post cleanup evidence comment
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.cleanup.outputs.pr_number }}
+          STATUS: ${{ steps.cleanup.outputs.status }}
+          APPLIED: ${{ steps.cleanup.outputs.applied }}
+          FAILED: ${{ steps.cleanup.outputs.failed }}
+          SKIPPED: ${{ steps.cleanup.outputs.skipped }}
+          BLOCKED: ${{ steps.cleanup.outputs.blocked }}
+        run: |
+          # Avoid a duplicate evidence comment: an agent's own local F4 run
+          # can have already posted one before this workflow fires. Skip if
+          # a `<!-- idd-cleanup-evidence: ... -->` comment already on the PR
+          # was posted by a trusted author -- this workflow's own posts are
+          # authored by `github-actions[bot]` (the GITHUB_TOKEN actor), and
+          # an agent's local F4 post is authored by a configured
+          # `trustedMarkerActors` login. An untrusted commenter pre-posting
+          # this marker prefix must never suppress the genuine evidence post
+          # or be treated as a completed cleanup record -- the same
+          # trust-scoping every other IDD operational marker already
+          # applies. `|| true` on the config read keeps a missing/unreadable
+          # config file a soft "no extra trusted logins" instead of aborting
+          # this step under the default `set -e`/`pipefail`.
+          TRUSTED_LOGINS=$(
+            {
+              jq -r '(.trustedMarkerActors // [])[]' .github/idd/config.json 2>/dev/null || true
+              echo 'github-actions[bot]'
+            } | tr '[:upper:]' '[:lower:]'
+          )
+          # Captured into a variable, not process substitution: a failure
+          # inside `< <(gh api ...)` does not reliably propagate through
+          # this shell's default `-e`/`pipefail`, which could leave
+          # EXISTING empty and post a duplicate comment on a transient
+          # `gh api` failure (rate limit/network). A plain command
+          # substitution assignment does trip `-e` on failure.
+          COMMENTS_TSV=$(gh api --paginate \
+            "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+            --jq '.[] | select(.body | startswith("<!-- idd-cleanup-evidence:")) | [.id, .user.login] | @tsv')
+          EXISTING=""
+          while IFS=$'\t' read -r candidate_id candidate_login; do
+            [ -z "$candidate_id" ] && continue
+            lower_login=$(printf '%s' "$candidate_login" | tr '[:upper:]' '[:lower:]')
+            if printf '%s\n' "$TRUSTED_LOGINS" | grep -Fxq "$lower_login"; then
+              EXISTING="$candidate_id"
+              break
+            fi
+          done <<< "$COMMENTS_TSV"
+          if [ -n "$EXISTING" ]; then
+            echo "::notice::PR #${PR_NUMBER} already has a trusted-author idd-cleanup-evidence comment (id: ${EXISTING}); skipping workflow post."
+            exit 0
+          fi
+          BODY=$(printf '%s\n\n%s\n\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n' \
+            "<!-- idd-cleanup-evidence: ${STATUS} applied:${APPLIED} failed:${FAILED} skipped:${SKIPPED} viewer-cannot-minimize:${BLOCKED} -->" \
+            "**F4 Cleanup Evidence** (server-side fallback via \`post-merge-cleanup.yml\`)" \
+            "| Field              | Value |" \
+            "| ------------------ | ----- |" \
+            "| Status             | ${STATUS} |" \
+            "| Applied            | ${APPLIED} |" \
+            "| Failed             | ${FAILED} |" \
+            "| Skipped            | ${SKIPPED} |" \
+            "| Permission-blocked | ${BLOCKED} |" \
+            "| Posted by          | post-merge-cleanup workflow |" \
+          )
+          printf '%s' "$BODY" | gh pr comment "$PR_NUMBER" --body-file -

--- a/.github/workflows/post-merge-cleanup.yml
+++ b/.github/workflows/post-merge-cleanup.yml
@@ -3,10 +3,13 @@
 # safe here only because all of the following hold, and any future edit to
 # this file must preserve them:
 #   - No unreviewed PR-head content is ever checked out: the checkout step
-#     below carries no `ref:` override, so it resolves to the
-#     `pull_request_target` default -- the base branch's tip at event time,
-#     which (because the job only proceeds when `merged == true`) already
-#     includes this PR's own merge commit. It is never the PR's own head SHA.
+#     below pins `ref:` to the merge commit for a `pull_request_target`
+#     event (`github.event.pull_request.merge_commit_sha`, only populated
+#     once `merged == true`), and falls back to the hardcoded default branch
+#     for `workflow_dispatch` -- never to `github.ref`'s implicit default,
+#     which for `workflow_dispatch` is whatever ref the dispatcher targeted
+#     (not restricted to a trusted value by the platform, unlike
+#     `pull_request_target`). It is never the PR's own head SHA.
 #   - No PR-head code, workflow, or action is ever executed: the cleanup
 #     invocation below runs `pnpm exec idd-audit-pr-cleanup`, which resolves
 #     against this repository's own already-reviewed, already-merged
@@ -66,6 +69,10 @@ jobs:
       - name: Stages the merged base branch
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
+          # See the header comment's trust-model note: pinned to the merge
+          # commit (real merge event) or the default branch (manual
+          # dispatch), never to github.ref's own dispatch-controlled value.
+          ref: ${{ github.event.pull_request.merge_commit_sha || 'main' }}
           persist-credentials: false
       - name: Setup the pnpm
         uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
@@ -95,7 +102,7 @@ jobs:
           # empty or non-numeric value fails loudly and immediately, rather
           # than as a confusing downstream `gh`/helper error (also protects
           # the next step, which only runs after this one succeeds).
-          if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+          if ! [[ "$PR_NUMBER" =~ ^[1-9][0-9]*$ ]]; then
             echo "::error::PR_NUMBER is not a valid positive integer: \"$PR_NUMBER\""
             exit 1
           fi
@@ -166,15 +173,25 @@ jobs:
               echo 'github-actions[bot]'
             } | tr '[:upper:]' '[:lower:]'
           )
-          # Captured into a variable, not process substitution: a failure
-          # inside `< <(gh api ...)` does not reliably propagate through
-          # this shell's default `-e`/`pipefail`, which could leave
-          # EXISTING empty and post a duplicate comment on a transient
-          # `gh api` failure (rate limit/network). A plain command
-          # substitution assignment does trip `-e` on failure.
+          # This workflow is a best-effort backstop, and the cleanup step
+          # above already did the actual minimization work -- a transient
+          # `gh api` failure here (rate limit/network) must not turn the
+          # whole run red over evidence-posting alone. Captured into a
+          # variable, not process substitution: a failure inside
+          # `< <(gh api ...)` does not reliably propagate through this
+          # shell's default `-e`/`pipefail`, which could leave EXISTING
+          # empty and post a duplicate comment. `set +e`/`set -e` bounds
+          # only this one fallible call.
+          set +e
           COMMENTS_TSV=$(gh api --paginate \
             "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
             --jq '.[] | select(.body | startswith("<!-- idd-cleanup-evidence:")) | [.id, .user.login] | @tsv')
+          LIST_EXIT=$?
+          set -e
+          if [ "$LIST_EXIT" -ne 0 ]; then
+            echo "::warning::could not list PR #${PR_NUMBER}'s comments (gh exit $LIST_EXIT); skipping evidence post to avoid guessing at duplicate state. Cleanup itself already ran in the previous step."
+            exit 0
+          fi
           EXISTING=""
           while IFS=$'\t' read -r candidate_id candidate_login; do
             [ -z "$candidate_id" ] && continue
@@ -200,4 +217,9 @@ jobs:
             "| Permission-blocked | ${BLOCKED} |" \
             "| Posted by          | post-merge-cleanup workflow |" \
           )
-          printf '%s' "$BODY" | gh pr comment "$PR_NUMBER" --body-file -
+          # Best-effort post, same rationale as the comment-list read above:
+          # a failed post (permissions/rate limit/transient) must not fail
+          # this job when the actual cleanup already succeeded.
+          if ! printf '%s' "$BODY" | gh pr comment "$PR_NUMBER" --body-file -; then
+            echo "::warning::could not post the cleanup evidence comment on PR #${PR_NUMBER}. Cleanup itself already ran in the previous step; post it manually or re-run this workflow via workflow_dispatch."
+          fi

--- a/.github/workflows/post-merge-cleanup.yml
+++ b/.github/workflows/post-merge-cleanup.yml
@@ -261,7 +261,7 @@ jobs:
           # line-oriented `read` loop below.
           COMMENTS_TSV=$(gh api --paginate \
             "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
-            --jq '.[] | select(.body | startswith("<!-- idd-cleanup-evidence:")) | [.id, .user.login, ((.body | capture("idd-cleanup-evidence:\\s*(?<s>\\S+)")).s // "unknown")] | @tsv')
+            --jq '.[] | select(.body | startswith("<!-- idd-cleanup-evidence:")) | [.id, .user.login, ((.body | try capture("idd-cleanup-evidence:\\s*(?<s>\\S+)") catch null).s // "unknown")] | @tsv')
           LIST_EXIT=$?
           set -e
           if [ "$LIST_EXIT" -ne 0 ]; then

--- a/.github/workflows/post-merge-cleanup.yml
+++ b/.github/workflows/post-merge-cleanup.yml
@@ -90,6 +90,15 @@ jobs:
           # expression directly into the run: script.
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.inputs.pr_number }}
         run: |
+          # workflow_dispatch's `type: number` constraint is a UI hint only,
+          # not enforced for a direct API dispatch -- validate here so an
+          # empty or non-numeric value fails loudly and immediately, rather
+          # than as a confusing downstream `gh`/helper error (also protects
+          # the next step, which only runs after this one succeeds).
+          if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+            echo "::error::PR_NUMBER is not a valid positive integer: \"$PR_NUMBER\""
+            exit 1
+          fi
           set +e
           JSON=$(pnpm exec idd-audit-pr-cleanup --pr "$PR_NUMBER" --apply --skip-claim-check --format json 2>cleanup-stderr.log)
           HELPER_EXIT=$?

--- a/.github/workflows/post-merge-cleanup.yml
+++ b/.github/workflows/post-merge-cleanup.yml
@@ -28,14 +28,29 @@
 #     through `env:` and referenced as a quoted shell variable, never
 #     interpolated directly into a `run:` script.
 #   - The `cleanup` job only runs when `github.event.pull_request.merged ==
-#     true`, or via an explicit, human-triggered `workflow_dispatch` --
-#     never against an open or unmerged pull request.
+#     true`; for `workflow_dispatch` the run F4 cleanup step separately
+#     verifies the target PR is actually merged before doing anything, and
+#     fails closed (not best-effort) if that check itself cannot be made --
+#     never against an open or unmerged pull request either way.
 #   - `permissions:` stays least-privilege: `contents: read`, `issues:
 #     write`, `pull-requests: write` -- no `contents: write` and no
 #     elevated or secret-bearing scopes.
-# If a future change adds a `ref:` override on the checkout step, downloads
-# or executes PR-head content, widens `permissions:`, or removes the
-# merged-only guard, re-review this trust model before merging that change.
+#   - The job `if:` also requires `github.ref == 'refs/heads/main'` for
+#     `workflow_dispatch` specifically. This is accident-protection, not a
+#     security boundary: workflow_dispatch already requires collaborator
+#     write access to trigger at all, and GitHub resolves a dispatch's own
+#     workflow *definition* (not just the checkout content) from whichever
+#     ref the dispatcher targets -- a modified copy of this very file on a
+#     non-default branch could remove this guard before it ever runs. The
+#     realistic threat model this narrows is a maintainer's own mistaken
+#     `--ref <branch>` dispatch, not an external escalation; only dispatch
+#     this workflow from the default branch (the GitHub UI's "Run workflow"
+#     button already defaults to it) and never via an explicit non-default
+#     `--ref`.
+# If a future change adds a `ref:` override on the pull_request_target
+# checkout step, downloads or executes PR-head content, widens
+# `permissions:`, or removes the merged-only guard, re-review this trust
+# model before merging that change.
 #
 # Server-side fallback for the agent's own F4 cleanup step
 # (idd-merge.instructions.md): the agent's local F4 run stays the primary,
@@ -71,7 +86,9 @@ concurrency:
   cancel-in-progress: false
 jobs:
   cleanup:
-    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
+    # See the header comment's accident-protection note on the
+    # workflow_dispatch + github.ref == 'refs/heads/main' clause.
+    if: github.event.pull_request.merged == true || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -121,6 +138,24 @@ jobs:
             echo "::error::PR_NUMBER is not a valid positive integer: \"$PR_NUMBER\""
             exit 1
           fi
+          # For workflow_dispatch specifically: the job-level if: has no way
+          # to check an *arbitrary dispatched* PR number's own merge state
+          # (only the triggering event's own pull_request.merged, which is
+          # absent for workflow_dispatch). An unmerged target here would run
+          # the helper against an open PR's comments and then post an
+          # idd-cleanup-evidence marker as if F4 had genuinely run -- which
+          # would poison the presence-only-record dedup guard below and
+          # suppress the real evidence post once the PR actually merges
+          # later. This check guards a mutation, so it fails closed (unlike
+          # the best-effort handling further down): if `gh api` itself
+          # cannot be reached, do not proceed on an unverified assumption.
+          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+            MERGED=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq '.merged')
+            if [ "$MERGED" != "true" ]; then
+              echo "::error::PR #${PR_NUMBER} is not merged (gh reports merged=${MERGED}); refusing to run post-merge cleanup against it."
+              exit 1
+            fi
+          fi
           set +e
           JSON=$(pnpm exec idd-audit-pr-cleanup --pr "$PR_NUMBER" --apply --skip-claim-check --format json 2>cleanup-stderr.log)
           HELPER_EXIT=$?
@@ -139,6 +174,15 @@ jobs:
             FAILED=$(printf '%s' "$JSON" | jq -r '.summary.failed // 0')
             SKIPPED=$(printf '%s' "$JSON" | jq -r '.summary.skipped // 0')
             BLOCKED=$(printf '%s' "$JSON" | jq -r '.summary["viewer-cannot-minimize"] // 0')
+            # Up to 5 failed-candidate reasons for the failure-format
+            # comment's Notes field (docs/idd-comment-minimization.md); a
+            # summary count alone leaves a maintainer with no way to tell
+            # what needs remediation from the PR conversation.
+            NOTES=$(printf '%s' "$JSON" | jq -r '
+              [.failed[] | "- \(.url // .subjectId): \(.error // "unknown error")"]
+              | if length > 5 then .[0:5] + ["- ...and \(length - 5) more (see workflow run log)"] else . end
+              | join("\n")
+            ')
             if [ "$HELPER_EXIT" -ne 0 ]; then
               echo "::warning::idd-audit-pr-cleanup exited $HELPER_EXIT but emitted a valid JSON report; using helper status \"$STATUS\""
             fi
@@ -150,6 +194,7 @@ jobs:
             FAILED=0
             SKIPPED=0
             BLOCKED=0
+            NOTES="- idd-audit-pr-cleanup exited $HELPER_EXIT with no parseable JSON. First stderr line: $(head -n1 cleanup-stderr.log 2>/dev/null || echo '(none captured)')"
           fi
           {
             echo "pr_number=$PR_NUMBER"
@@ -158,6 +203,9 @@ jobs:
             echo "failed=$FAILED"
             echo "skipped=$SKIPPED"
             echo "blocked=$BLOCKED"
+            echo "notes<<NOTES_EOF"
+            echo "$NOTES"
+            echo "NOTES_EOF"
           } >> "$GITHUB_OUTPUT"
       - name: Post cleanup evidence comment
         env:
@@ -168,20 +216,29 @@ jobs:
           FAILED: ${{ steps.cleanup.outputs.failed }}
           SKIPPED: ${{ steps.cleanup.outputs.skipped }}
           BLOCKED: ${{ steps.cleanup.outputs.blocked }}
+          NOTES: ${{ steps.cleanup.outputs.notes }}
         run: |
-          # Avoid a duplicate evidence comment: an agent's own local F4 run
-          # can have already posted one before this workflow fires. Skip if
-          # a `<!-- idd-cleanup-evidence: ... -->` comment already on the PR
-          # was posted by a trusted author -- this workflow's own posts are
-          # authored by `github-actions[bot]` (the GITHUB_TOKEN actor), and
-          # an agent's local F4 post is authored by a configured
-          # `trustedMarkerActors` login. An untrusted commenter pre-posting
-          # this marker prefix must never suppress the genuine evidence post
-          # or be treated as a completed cleanup record -- the same
-          # trust-scoping every other IDD operational marker already
-          # applies. `|| true` on the config read keeps a missing/unreadable
-          # config file a soft "no extra trusted logins" instead of aborting
-          # this step under the default `set -e`/`pipefail`.
+          # Avoid stacking a duplicate evidence comment on top of one an
+          # agent's own local F4 run (or an earlier run of this same
+          # workflow) already posted -- scoped to a trusted author, same as
+          # every other IDD operational marker: this workflow's own posts
+          # are authored by `github-actions[bot]` (the GITHUB_TOKEN actor),
+          # an agent's local F4 post by a configured `trustedMarkerActors`
+          # login. An untrusted commenter pre-posting this marker prefix
+          # must never suppress the genuine evidence post or be treated as
+          # a completed cleanup record. `|| true` on the config read keeps a
+          # missing/unreadable config file a soft "no extra trusted logins"
+          # instead of aborting this step under the default `-e`/`pipefail`.
+          #
+          # Known, accepted residual race (not fixed here): the agent's own
+          # local F4 step and this workflow can both list comments before
+          # either has posted, both see no existing marker, and both post --
+          # a cosmetic duplicate record, not a correctness issue (the
+          # underlying comment-minimization work is idempotent either way).
+          # Upstream idd-skill's own post-merge-cleanup.yml template has the
+          # identical presence-check-then-post race; a fully atomic guard
+          # would need cross-process coordination this best-effort fallback
+          # does not warrant.
           TRUSTED_LOGINS=$(
             {
               jq -r '(.trustedMarkerActors // [])[]' .github/idd/config.json 2>/dev/null || true
@@ -198,43 +255,86 @@ jobs:
           # empty and post a duplicate comment. `set +e`/`set -e` bounds
           # only this one fallible call.
           set +e
+          # Extracts just the marker's {status} token (not the full,
+          # multi-line comment body) into the TSV row -- @tsv does not
+          # escape embedded newlines, so a full body would break the
+          # line-oriented `read` loop below.
           COMMENTS_TSV=$(gh api --paginate \
             "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
-            --jq '.[] | select(.body | startswith("<!-- idd-cleanup-evidence:")) | [.id, .user.login] | @tsv')
+            --jq '.[] | select(.body | startswith("<!-- idd-cleanup-evidence:")) | [.id, .user.login, ((.body | capture("idd-cleanup-evidence:\\s*(?<s>\\S+)")).s // "unknown")] | @tsv')
           LIST_EXIT=$?
           set -e
           if [ "$LIST_EXIT" -ne 0 ]; then
             echo "::warning::could not list PR #${PR_NUMBER}'s comments (gh exit $LIST_EXIT); skipping evidence post to avoid guessing at duplicate state. Cleanup itself already ran in the previous step."
             exit 0
           fi
+          # Status-aware, not presence-only: an existing trusted marker
+          # blocks a new post only when it already records a settled
+          # success (applied/clean). A failed/incomplete/helper-error
+          # record must not permanently mask a later successful rerun (the
+          # correction rule in idd-merge.instructions.md's duplicate-
+          # success-record skip rule) -- update that comment in place
+          # instead of creating a second one.
           EXISTING=""
-          while IFS=$'\t' read -r candidate_id candidate_login; do
+          EXISTING_STATUS=""
+          while IFS=$'\t' read -r candidate_id candidate_login candidate_status; do
             [ -z "$candidate_id" ] && continue
             lower_login=$(printf '%s' "$candidate_login" | tr '[:upper:]' '[:lower:]')
             if printf '%s\n' "$TRUSTED_LOGINS" | grep -Fxq "$lower_login"; then
               EXISTING="$candidate_id"
+              EXISTING_STATUS="$candidate_status"
               break
             fi
           done <<< "$COMMENTS_TSV"
           if [ -n "$EXISTING" ]; then
-            echo "::notice::PR #${PR_NUMBER} already has a trusted-author idd-cleanup-evidence comment (id: ${EXISTING}); skipping workflow post."
-            exit 0
+            case "$EXISTING_STATUS" in
+              applied | clean)
+                echo "::notice::PR #${PR_NUMBER} already has a trusted-author idd-cleanup-evidence comment recording a settled success (id: ${EXISTING}, status: ${EXISTING_STATUS}); skipping workflow post."
+                exit 0
+                ;;
+            esac
+            echo "::notice::PR #${PR_NUMBER}'s existing idd-cleanup-evidence comment (id: ${EXISTING}) records a non-success status \"${EXISTING_STATUS}\"; updating it in place with this run's outcome instead of posting a second one."
           fi
-          BODY=$(printf '%s\n\n%s\n\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n' \
-            "<!-- idd-cleanup-evidence: ${STATUS} applied:${APPLIED} failed:${FAILED} skipped:${SKIPPED} viewer-cannot-minimize:${BLOCKED} -->" \
-            "**F4 Cleanup Evidence** (server-side fallback via \`post-merge-cleanup.yml\`)" \
-            "| Field              | Value |" \
-            "| ------------------ | ----- |" \
-            "| Status             | ${STATUS} |" \
-            "| Applied            | ${APPLIED} |" \
-            "| Failed             | ${FAILED} |" \
-            "| Skipped            | ${SKIPPED} |" \
-            "| Permission-blocked | ${BLOCKED} |" \
-            "| Posted by          | post-merge-cleanup workflow |" \
-          )
+          case "$STATUS" in
+            applied | clean)
+              BODY=$(printf '%s\n\n%s\n\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n' \
+                "<!-- idd-cleanup-evidence: ${STATUS} applied:${APPLIED} failed:${FAILED} skipped:${SKIPPED} viewer-cannot-minimize:${BLOCKED} -->" \
+                "**F4 Cleanup Evidence** (server-side fallback via \`post-merge-cleanup.yml\`)" \
+                "| Field              | Value |" \
+                "| ------------------ | ----- |" \
+                "| Status             | ${STATUS} |" \
+                "| Applied            | ${APPLIED} |" \
+                "| Failed             | ${FAILED} |" \
+                "| Skipped            | ${SKIPPED} |" \
+                "| Permission-blocked | ${BLOCKED} |" \
+                "| Posted by          | post-merge-cleanup workflow |" \
+              )
+              ;;
+            *)
+              # docs/idd-comment-minimization.md's "Cleanup-failure comment"
+              # format: distinct from the success table above, and carries
+              # the Notes the failure-detail extraction above built.
+              BODY=$(printf '%s\n\n%s\n\n%s\n\n%s\n%s\n%s\n%s\n%s\n\n%s\n%s\n' \
+                "<!-- idd-cleanup-evidence: ${STATUS} applied:${APPLIED} failed:${FAILED} skipped:${SKIPPED} viewer-cannot-minimize:${BLOCKED} -->" \
+                "**F4 Cleanup Failure** (server-side fallback via \`post-merge-cleanup.yml\`)" \
+                "Cleanup candidates were detected but not all could be applied." \
+                "- Status: ${STATUS}" \
+                "- Applied: ${APPLIED}" \
+                "- Failed: ${FAILED}" \
+                "- Skipped: ${SKIPPED}" \
+                "- Permission-blocked: ${BLOCKED}" \
+                "Notes:" \
+                "${NOTES:-- (no per-candidate detail captured; see the workflow run log)}" \
+              )
+              ;;
+          esac
           # Best-effort post, same rationale as the comment-list read above:
           # a failed post (permissions/rate limit/transient) must not fail
           # this job when the actual cleanup already succeeded.
-          if ! printf '%s' "$BODY" | gh pr comment "$PR_NUMBER" --body-file -; then
+          if [ -n "$EXISTING" ]; then
+            if ! gh api --method PATCH "repos/${GITHUB_REPOSITORY}/issues/comments/${EXISTING}" -f body="$BODY" >/dev/null; then
+              echo "::warning::could not update the existing cleanup evidence comment (id: ${EXISTING}) on PR #${PR_NUMBER}. Cleanup itself already ran in the previous step; update it manually or re-run this workflow via workflow_dispatch."
+            fi
+          elif ! printf '%s' "$BODY" | gh pr comment "$PR_NUMBER" --body-file -; then
             echo "::warning::could not post the cleanup evidence comment on PR #${PR_NUMBER}. Cleanup itself already ran in the previous step; post it manually or re-run this workflow via workflow_dispatch."
           fi

--- a/.github/workflows/post-merge-cleanup.yml
+++ b/.github/workflows/post-merge-cleanup.yml
@@ -2,14 +2,23 @@
 # with base-repository permissions and secrets even for a fork PR. That is
 # safe here only because all of the following hold, and any future edit to
 # this file must preserve them:
-#   - No unreviewed PR-head content is ever checked out: the checkout step
-#     below pins `ref:` to the merge commit for a `pull_request_target`
-#     event (`github.event.pull_request.merge_commit_sha`, only populated
-#     once `merged == true`), and falls back to the hardcoded default branch
-#     for `workflow_dispatch` -- never to `github.ref`'s implicit default,
-#     which for `workflow_dispatch` is whatever ref the dispatcher targeted
-#     (not restricted to a trusted value by the platform, unlike
-#     `pull_request_target`). It is never the PR's own head SHA.
+#   - No unreviewed PR-head content is ever checked out: the `pull_request_target`
+#     path below carries no `ref:` override at all, so it resolves to that
+#     trigger's own default -- the base branch's tip at event time (CodeQL's
+#     `actions/untrusted-checkout` query specifically recognizes this
+#     no-override pattern as safe for `pull_request_target`; an earlier
+#     revision here explicitly pinned `ref:` to
+#     `github.event.pull_request.merge_commit_sha` instead, which is
+#     substantively just as safe -- gated behind `merged == true`, so it is
+#     already-reviewed, already-merged content -- but CodeQL's static query
+#     cannot prove that from the job-level `if:` alone and flagged it
+#     critical; reverted rather than argue with a security scanner over a
+#     pattern with an available, equally-safe, unflagged alternative). The
+#     separate `workflow_dispatch` path uses its own checkout step, pinned
+#     to the hardcoded default branch -- never to `github.ref`'s implicit
+#     default, which for `workflow_dispatch` is whatever ref the dispatcher
+#     targeted and is not restricted to a trusted value by the platform.
+#     Neither path ever checks out the PR's own head SHA.
 #   - No PR-head code, workflow, or action is ever executed: the cleanup
 #     invocation below runs `pnpm exec idd-audit-pr-cleanup`, which resolves
 #     against this repository's own already-reviewed, already-merged
@@ -66,13 +75,19 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      # Two checkout steps, not one with a combined ref: expression -- see
+      # the header comment's trust-model note on why the pull_request_target
+      # path stays override-free.
       - name: Stages the merged base branch
+        if: github.event_name != 'workflow_dispatch'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          # See the header comment's trust-model note: pinned to the merge
-          # commit (real merge event) or the default branch (manual
-          # dispatch), never to github.ref's own dispatch-controlled value.
-          ref: ${{ github.event.pull_request.merge_commit_sha || 'main' }}
+          persist-credentials: false
+      - name: Stages the default branch (manual dispatch)
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: main
           persist-credentials: false
       - name: Setup the pnpm
         uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4

--- a/.github/workflows/post-merge-cleanup.yml
+++ b/.github/workflows/post-merge-cleanup.yml
@@ -275,24 +275,43 @@ jobs:
           # correction rule in idd-merge.instructions.md's duplicate-
           # success-record skip rule) -- update that comment in place
           # instead of creating a second one.
+          #
+          # Scan every trusted row rather than stopping at the first match:
+          # the issues-comments API returns comments oldest-first, so if an
+          # older trusted failure record and a newer trusted success record
+          # ever coexist (for example, the agent-side F4 rule's own
+          # duplicate-success-record skip rule posts a fresh comment for a
+          # correction rather than updating one in place), stopping at the
+          # first (oldest) row would grab the stale failure, miss the
+          # already-present success, and -- worse -- go on to PATCH that
+          # old failure into a second success record. A success anywhere in
+          # the list always wins regardless of position; only when none
+          # exists does the last-seen non-success row become the one this
+          # run updates in place.
           EXISTING=""
           EXISTING_STATUS=""
+          SUCCESS_ID=""
           while IFS=$'\t' read -r candidate_id candidate_login candidate_status; do
             [ -z "$candidate_id" ] && continue
             lower_login=$(printf '%s' "$candidate_login" | tr '[:upper:]' '[:lower:]')
-            if printf '%s\n' "$TRUSTED_LOGINS" | grep -Fxq "$lower_login"; then
-              EXISTING="$candidate_id"
-              EXISTING_STATUS="$candidate_status"
-              break
+            if ! printf '%s\n' "$TRUSTED_LOGINS" | grep -Fxq "$lower_login"; then
+              continue
             fi
-          done <<< "$COMMENTS_TSV"
-          if [ -n "$EXISTING" ]; then
-            case "$EXISTING_STATUS" in
+            case "$candidate_status" in
               applied | clean)
-                echo "::notice::PR #${PR_NUMBER} already has a trusted-author idd-cleanup-evidence comment recording a settled success (id: ${EXISTING}, status: ${EXISTING_STATUS}); skipping workflow post."
-                exit 0
+                SUCCESS_ID="$candidate_id"
+                ;;
+              *)
+                EXISTING="$candidate_id"
+                EXISTING_STATUS="$candidate_status"
                 ;;
             esac
+          done <<< "$COMMENTS_TSV"
+          if [ -n "$SUCCESS_ID" ]; then
+            echo "::notice::PR #${PR_NUMBER} already has a trusted-author idd-cleanup-evidence comment recording a settled success (id: ${SUCCESS_ID}); skipping workflow post."
+            exit 0
+          fi
+          if [ -n "$EXISTING" ]; then
             echo "::notice::PR #${PR_NUMBER}'s existing idd-cleanup-evidence comment (id: ${EXISTING}) records a non-success status \"${EXISTING_STATUS}\"; updating it in place with this run's outcome instead of posting a second one."
           fi
           case "$STATUS" in
@@ -312,9 +331,12 @@ jobs:
               ;;
             *)
               # docs/idd-comment-minimization.md's "Cleanup-failure comment"
-              # format: distinct from the success table above, and carries
-              # the Notes the failure-detail extraction above built.
-              BODY=$(printf '%s\n\n%s\n\n%s\n\n%s\n%s\n%s\n%s\n%s\n\n%s\n%s\n' \
+              # format: distinct from the success table above, carries the
+              # Notes the failure-detail extraction above built, and the
+              # doc's own required manual-recovery line (using this
+              # repository's package-manager CLI facade, not the doc's
+              # vendored-node example command).
+              BODY=$(printf '%s\n\n%s\n\n%s\n\n%s\n%s\n%s\n%s\n%s\n\n%s\n%s\n\n%s\n%s\n' \
                 "<!-- idd-cleanup-evidence: ${STATUS} applied:${APPLIED} failed:${FAILED} skipped:${SKIPPED} viewer-cannot-minimize:${BLOCKED} -->" \
                 "**F4 Cleanup Failure** (server-side fallback via \`post-merge-cleanup.yml\`)" \
                 "Cleanup candidates were detected but not all could be applied." \
@@ -325,6 +347,8 @@ jobs:
                 "- Permission-blocked: ${BLOCKED}" \
                 "Notes:" \
                 "${NOTES:-- (no per-candidate detail captured; see the workflow run log)}" \
+                "This does not re-block the merge. A maintainer may run cleanup manually:" \
+                "\`pnpm exec idd-audit-pr-cleanup --pr ${PR_NUMBER} --apply --skip-claim-check\`" \
               )
               ;;
           esac

--- a/docs/idd-comment-minimization.md
+++ b/docs/idd-comment-minimization.md
@@ -393,9 +393,15 @@ never stacks a duplicate success record — even when this run's own apply
 returned `applied` for residual markers a concurrent `post-merge-cleanup`
 workflow run minimized first; still post when no prior success record
 exists, or to correct an existing `failed` / `incomplete` /
-`permission-blocked` record. The `post-merge-cleanup` workflow instead
-uses a simpler presence-only guard (it skips on any existing marker),
-which suffices for its single-shot post-merge run:
+`permission-blocked` record. A generic `post-merge-cleanup` workflow
+using a simpler presence-only guard (skip on any existing marker,
+regardless of its recorded status) would still suffice for a genuinely
+single-shot post-merge run, but this repository's own
+`.github/workflows/post-merge-cleanup.yml` (issue #96) implements the
+same status-aware rule as the agent-side one above instead — its
+`workflow_dispatch` re-run path makes "single-shot" not actually hold
+here, so a stale `failed` record needs the same correction path a
+manual re-run could otherwise never clear:
 
 ```markdown
 <!-- idd-cleanup-evidence: {status} applied:{N} failed:{N} skipped:{N} viewer-cannot-minimize:{N} -->

--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -255,6 +255,23 @@ this PR, the entire `Run idd-doctor` step (14-day scan included)
 completed in under a second, so there is no timeout risk to trade
 coverage against here.
 
+The checkout step passes `fetch-depth: 0` (full history and tags): the
+default shallow `fetch-depth: 1` hides tag refs, which silently skips
+`idd-doctor`'s release-tag-drift check (`git describe --tags` fails and
+the check returns with no warning, rather than erroring) — confirmed
+by tracing `checkReleaseTagDrift` in the pinned `idd-skill` source. The
+job also carries a `concurrency:` block (`cancel-in-progress: true`,
+grouped by `${{ github.workflow }}-${{ github.ref }}`), matching
+`idd-advisory-convergence.yml`'s own pattern, so a rapid string of
+pushes to the same PR does not queue redundant runs.
+
+`idd-doctor`'s post-merge cleanup-backlog scan already scopes itself to
+IDD-branch merged PRs only (`idd-skill` upstream issue #1829), so a
+routine Dependabot merge never counts toward the backlog total. This
+scoping lives inside the vendored `@kurone-kito/idd-skill` package
+(pinned to `v0.6.0` by issue #92) — it took effect automatically when
+the pin was bumped, with no workflow-file or config change needed here.
+
 The job's `permissions:` grants `issues: read` and `pull-requests: read`
 alongside `contents: read`, and its `gh`-calling step sets
 `GH_TOKEN: ${{ github.token }}`. Without both, `gh` has no credential

--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -364,14 +364,16 @@ F4 already runs the same helper in-session.
 It triggers on `pull_request_target: closed` (not `pull_request`) so a
 fork PR's merge still runs it with base-repository credentials, gated
 by `github.event.pull_request.merged == true` so it never fires on a
-closed-without-merge PR. The checkout step pins `ref:` to the merge
-commit (`github.event.pull_request.merge_commit_sha`) for a real merge
-event, or the hardcoded default branch for a manual
-`workflow_dispatch` — never to `github.ref`'s own implicit default,
-which for `workflow_dispatch` is whatever ref the dispatcher targeted
-and is not restricted to a trusted value by the platform. Either way
-it is never PR-head content — and `permissions:` stays `contents:
-read` / `issues: write` /
+closed-without-merge PR. Two separate checkout steps handle the two
+triggers: the `pull_request_target` path carries no `ref:` override at
+all (resolving to that trigger's own trusted base-branch-tip default —
+the pattern GitHub's `actions/untrusted-checkout` CodeQL query
+recognizes as safe), and the `workflow_dispatch` path pins `ref:` to
+the hardcoded default branch — never to `github.ref`'s own implicit
+default, which for `workflow_dispatch` is whatever ref the dispatcher
+targeted and is not restricted to a trusted value by the platform.
+Neither path ever checks out PR-head content, and `permissions:` stays
+`contents: read` / `issues: write` /
 `pull-requests: write`, matching this workflow's actual mutation
 surface (comment minimization and a single evidence comment; no
 repository-content write). See the workflow file's own header comment

--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -324,6 +324,29 @@ of its own, so GitHub associates it with the dispatch ref rather than
 the PR's HEAD SHA, and the resulting run's conclusion can be invisible
 to the PR's required-check rollup.
 
+**Policy-engine model (v0.5.0/v0.6.0)**: the workflow file itself is a
+thin wrapper — `--pr "$PR_NUMBER" --assert` — around
+`@kurone-kito/idd-skill`'s `advisory-convergence.mjs` helper. The
+same-HEAD reroll cap, Copilot stall-recovery state contract, and
+maintainer-waiver backstop upstream added in `v0.5.0` all live inside
+that vendored helper, not in the workflow YAML, so bumping the pinned
+`idd-skill` version (issue #92, now `v0.6.0`) already brought this
+workflow's *behavior* fully current with no shape change needed here.
+This repository's own workflow file already matched upstream's
+dogfooded copy (triggers, permissions, concurrency group, job id, even
+the pinned `actions/checkout` SHA) before this issue, confirmed by a
+line-by-line diff against `idd-skill`'s repository at the pinned
+commit.
+
+**Claimless external-check-waiver** (`v0.6.0`'s claim-id `none`
+sentinel plus a `--claimless` authoring-CLI flag, for a waiver on a PR
+with no active IDD claim to bind to) is deliberately **not** adopted:
+this repository's PR history has exactly two authors,
+`app/dependabot` (already exempt via `advisoryWait.exemptBotAuthoredPrs`)
+and the sole maintainer (whose PRs always carry an active claim), so
+the claim-id `none` sentinel has no real use case here. Revisit if this
+repository ever accepts a non-bot, non-maintainer contribution.
+
 ### Worktree guard
 
 **Policy**: `worktreeGuard.enabled: true` in `.github/idd/config.json`.

--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -364,9 +364,14 @@ F4 already runs the same helper in-session.
 It triggers on `pull_request_target: closed` (not `pull_request`) so a
 fork PR's merge still runs it with base-repository credentials, gated
 by `github.event.pull_request.merged == true` so it never fires on a
-closed-without-merge PR. The checkout step carries no `ref:` override —
-it resolves to the base branch's tip, never PR-head content — and
-`permissions:` stays `contents: read` / `issues: write` /
+closed-without-merge PR. The checkout step pins `ref:` to the merge
+commit (`github.event.pull_request.merge_commit_sha`) for a real merge
+event, or the hardcoded default branch for a manual
+`workflow_dispatch` — never to `github.ref`'s own implicit default,
+which for `workflow_dispatch` is whatever ref the dispatcher targeted
+and is not restricted to a trusted value by the platform. Either way
+it is never PR-head content — and `permissions:` stays `contents:
+read` / `issues: write` /
 `pull-requests: write`, matching this workflow's actual mutation
 surface (comment minimization and a single evidence comment; no
 repository-content write). See the workflow file's own header comment

--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -347,6 +347,31 @@ and the sole maintainer (whose PRs always carry an active claim), so
 the claim-id `none` sentinel has no real use case here. Revisit if this
 repository ever accepts a non-bot, non-maintainer contribution.
 
+### `post-merge-cleanup` workflow
+
+`.github/workflows/post-merge-cleanup.yml` (added by issue #96,
+mirroring `idd-template`'s `v0.6.0` core file) is a server-side
+fallback for the agent's own F4 cleanup step
+(`idd-merge.instructions.md`): it re-runs
+`pnpm exec idd-audit-pr-cleanup --pr <n> --apply --skip-claim-check`
+unconditionally on every merged PR, so cleanup coverage never depends
+on the merging session having completed F4 itself (for example, a
+session that exits at the F4/F5 boundary before posting evidence).
+It skips posting a duplicate `<!-- idd-cleanup-evidence: -->` comment
+when a trusted-author one already exists — the ordinary case, since
+F4 already runs the same helper in-session.
+
+It triggers on `pull_request_target: closed` (not `pull_request`) so a
+fork PR's merge still runs it with base-repository credentials, gated
+by `github.event.pull_request.merged == true` so it never fires on a
+closed-without-merge PR. The checkout step carries no `ref:` override —
+it resolves to the base branch's tip, never PR-head content — and
+`permissions:` stays `contents: read` / `issues: write` /
+`pull-requests: write`, matching this workflow's actual mutation
+surface (comment minimization and a single evidence comment; no
+repository-content write). See the workflow file's own header comment
+for the full trust-model rationale.
+
 ### Worktree guard
 
 **Policy**: `worktreeGuard.enabled: true` in `.github/idd/config.json`.


### PR DESCRIPTION
Closes #96

## Summary

Reconciles this repository's `idd-doctor.yml` and
`idd-advisory-convergence.yml` CI gates against upstream `idd-skill`
`v0.5.0`/`v0.6.0` (pinned commit `0a9c90d`), and adds the new
`post-merge-cleanup.yml` core workflow.

## What changed, and why

### `idd-advisory-convergence.yml` — no code change

Line-by-line diff against `idd-skill`'s own dogfooded copy of this
workflow at the pinned commit showed this repository's file already
matches: same triggers, `permissions:`, `concurrency:` group, job id
(no `name:` override), and even the identical pinned `actions/checkout`
SHA. The `v0.5.0` policy-engine model (same-HEAD reroll cap, Copilot
stall-recovery, maintainer-waiver backstop) lives entirely inside the
vendored `advisory-convergence.mjs` helper, not the workflow YAML — so
bumping the `@kurone-kito/idd-skill` pin to `v0.6.0` in #92 already
brought this workflow's behavior fully current. This session's own PR
#100 review-triage exercised that machinery live (same-HEAD reroll,
disposition-evidence gating, the `idd-rerun-advisory-convergence`
stale-check recovery), confirming it works end-to-end.

`v0.6.0`'s claimless external-check-waiver (claim-id `none` sentinel)
is deliberately deferred: `gh pr list --state all` shows exactly two
PR authors in this repository's history, `app/dependabot` (already
exempt via `advisoryWait.exemptBotAuthoredPrs`) and the sole
maintainer (always claim-bound), so there is no PR shape that would
ever need it.

### `idd-doctor.yml` — reconciled, two real fixes

- **`fetch-depth: 0`** on the checkout step. Traced
  `checkReleaseTagDrift` in the pinned `idd-doctor.mts`: it calls
  `git describe --tags --abbrev=0` and silently `return`s on failure —
  no warning, no error. Under this workflow's previous default shallow
  `fetch-depth: 1`, tag refs are invisible, so the check has been
  silently skipping on every CI run since #50. Confirmed locally: a
  full-history `pnpm exec idd-doctor` run now correctly reports
  `release-tag drift: HEAD is 311 day(s) (> 45) past the latest tag
  v0.21.0`.
- **`concurrency:` block** added, matching `idd-advisory-convergence.yml`'s
  own `cancel-in-progress: true` / `${{ github.workflow }}-${{ github.ref }}`
  pattern, so a rapid push burst does not queue redundant runs.

**Comparison against upstream's own dogfooded `idd-doctor.yml`, as the
issue asked for:**

- `GH_TOKEN` + `issues: read` / `pull-requests: read`: this repository's
  existing grant (from #50) already matches upstream's `v0.6.0`
  equivalent exactly — no change needed.
- Post-merge cleanup-backlog window: this repository intentionally uses
  the full 14-day default (see `b6bf2c9` — measured at under 1s per
  run, no timeout risk), which is an orthogonal axis from upstream's
  own `v0.6.0` fix. That upstream fix — scoping the backlog scan to
  IDD-branch merged PRs only (`idd-skill` issue #1829, so a routine
  Dependabot merge never counts toward the total) — lives inside the
  vendored package and is already active here via the existing pin, no
  window-size conflict.
- Upstream's dogfooded copy also adds an explicit "Assert Node.js
  floor" step, guarding against `ubuntu-slim`'s *preinstalled* Node
  silently satisfying `import.meta.main`'s known-broken range
  (`idd-skill` issue #1447). **Not adopted**: this repository's job
  already pins an exact Node version via `actions/setup-node` +
  `.node-version` (currently `22.23.1`), so it never relies on
  whatever the runner happens to preinstall — the specific failure
  mode that guard exists for is structurally unreachable here.

### `post-merge-cleanup.yml` — new

Adapted from `idd-template`'s `v0.6.0` copy, stripped of the generic
template's `vendored-node`/`package-manager`/`ephemeral-npx`/
`instructions-only` branching (this repository's profile is fixed at
`package-manager` via pnpm, declared in `package.json`'s own
`packageManager` field) and rebuilt on this repository's established
SHA-pinned action/step-naming conventions. Server-side fallback for the
agent's own F4 cleanup step: re-runs `idd-audit-pr-cleanup --apply
--skip-claim-check` unconditionally on every merge, skipping a
duplicate evidence comment when a trusted-author one already exists.

### `docs/idd-policy.md`

Documents all of the above under "IDD Enforcement Gates".

## Test plan

- [x] `pnpm run lint:fix` / `pnpm run lint` pass
- [x] `pnpm run build` passes
- [x] `pnpm run test` passes (68 tests)
- [x] `pnpm exec idd-doctor` passes (3 pre-existing warnings, no
      errors; the release-tag-drift warning is the fix above actually
      firing for the first time)
- [x] `idd-advisory-convergence.yml`'s job id confirmed unchanged (no
      diff against the file at all)
- [ ] `post-merge-cleanup.yml` runs on this PR's own merge without
      error (verify after merge, per the issue's own acceptance
      criterion — cannot self-test before merging)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated post-merge cleanup checks for merged pull requests, with manual rerun support.
  * Added trusted cleanup evidence reporting while preventing duplicate status comments.
  * Added corrections for stale or incomplete cleanup status records.

* **Bug Fixes**
  * Improved workflow reliability by cancelling outdated runs and enabling tag-based validation.

* **Documentation**
  * Updated policy documentation to describe cleanup workflows, validation behavior, waiver handling, and backlog scoping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->