### PR TITLE
feat(root): strip reserved IDD labels applied by untrusted bots

### DIFF
--- a/.github/workflows/strip-untrusted-labels.yml
+++ b/.github/workflows/strip-untrusted-labels.yml
@@ -1,0 +1,112 @@
+# Trust model: this workflow triggers on `issues: labeled` and
+# `pull_request_target: labeled`, which each fire once per label
+# application and carry both `label.name` and `sender.login` (the actor
+# who applied that specific label) in the event payload -- no extra API
+# call is needed to attribute the mutation to an actor.
+#   - `pull_request_target`, not `pull_request`, for the PR branch: this
+#     is a public repository, so a label applied to a fork-originated PR
+#     is a realistic case, and a `pull_request`-triggered workflow gets an
+#     automatically read-only `GITHUB_TOKEN` for fork PRs regardless of
+#     the declared `permissions:` block below -- the label-removal call
+#     would silently 403 with no visible failure. `pull_request_target`
+#     grants the base-repository token scopes declared below regardless
+#     of fork origin. This is safe here for the same reason it is safe in
+#     `post-merge-cleanup.yml`: no repository content is ever checked out
+#     (see below), so there is no PR-supplied workflow or code to run
+#     with the elevated token.
+#   - The job runs only when BOTH hold for this one event:
+#     `github.event.sender.login` is `coderabbitai[bot]`, AND
+#     `github.event.label.name` is a reserved IDD operational label: the
+#     exact `roadmap` label, or any label whose name starts with
+#     `status:` (currently `status:authoring`, `status:needs-decision`,
+#     `status:blocked-by-human`; the prefix match also covers any future
+#     `status:*` label without needing to edit this condition). These are
+#     this repository's distributed-default label names
+#     (`.github/idd/config.json` has no `labels.*` override), matching
+#     the literal strings hardcoded below.
+#   - Actor list scope (issue #65): this repository's `advisoryBotLogins`
+#     config array also lists `copilot-pull-request-reviewer[bot]` and
+#     `chatgpt-codex-connector[bot]`, but a full repository-wide sweep of
+#     every `labeled` event in this repository's history (via
+#     `GET /repos/{owner}/{repo}/issues/events`, every issue and PR, not
+#     a recent sample) found label-write activity from only
+#     `coderabbitai[bot]` (plus `dependabot[bot]` on non-reserved labels
+#     and this repository's own `github-actions[bot]` stale-bot, both
+#     already harmless). Neither Copilot's review bot nor
+#     chatgpt-codex-connector has ever applied a label here, so they are
+#     deliberately excluded rather than guessed at -- add an entry only
+#     once a real `labeled` event confirms one of them writes labels too
+#     (re-run the same sweep), keeping this hardcoded list in sync with
+#     `advisoryBotLogins` only for entries with confirmed label-write
+#     behavior. The list is hardcoded rather than read from the config
+#     file because the `if:` condition evaluates before any step runs,
+#     and this workflow deliberately never checks out repository content
+#     (see below).
+#   - This is fail-safe by construction against ever re-fighting a human: a
+#     human re-adding the same label afterward is a *separate* `labeled`
+#     event whose `sender.login` is the human, not `coderabbitai[bot]`,
+#     so the condition above does not match and the human's re-add is
+#     left untouched. The guard never diffs current label state against a
+#     human decision -- it only ever reacts to the one label-add event it
+#     already fail-closed-matched by actor and label name.
+#   - No repository content is checked out (this job never runs
+#     `actions/checkout`) and no code from the issue/PR body, comments, or
+#     label metadata is executed. The job's only action is a single `gh`
+#     call that removes one already-known label from one already-known
+#     issue or pull request via the REST/GraphQL API; both values come
+#     from the trusted event payload and are passed through environment
+#     variables, never interpolated directly into a shell command string.
+#   - `permissions:` stays least-privilege: `issues: write` and
+#     `pull-requests: write` only -- no `contents` or other elevated
+#     scopes. `pull-requests: write` is required for the PR branch (`gh pr
+#     edit --remove-label` uses the PullRequest GraphQL type, distinct
+#     from the Issues-scoped REST path `gh issue edit` uses for the issue
+#     branch), in addition to `issues: write` for the issue branch.
+# If a future change widens the trigger, adds repository checkout, executes
+# issue/PR-supplied content, broadens `permissions:`, or widens the actor
+# list above without a corresponding confirmed `labeled` event, re-review
+# this trust model before merging that change.
+#
+# Adapted from upstream `kurone-kito/idd-skill`'s own dogfooded copy of
+# this recipe (`docs/customization.md#reserved-label-guard-recipe`), with
+# the actor list narrowed to this repository's own confirmed evidence
+# (see above) instead of copying upstream's list unchanged.
+name: Strip untrusted reserved IDD labels
+on:
+  issues:
+    types:
+      - labeled
+  pull_request_target:
+    types:
+      - labeled
+permissions:
+  issues: write
+  pull-requests: write
+concurrency:
+  group: strip-untrusted-labels-${{ github.event.issue.number || github.event.pull_request.number }}-${{ github.event.label.name }}
+  cancel-in-progress: true
+jobs:
+  strip-label:
+    if: |-
+      github.event.sender.login == 'coderabbitai[bot]' && (github.event.label.name == 'roadmap' || startsWith(github.event.label.name, 'status:'))
+    runs-on: ubuntu-latest
+    # A single `gh issue edit`/`gh pr edit` REST/GraphQL call; observed
+    # comparable single-call jobs in this repository complete in well
+    # under a minute. 5 min bounds a pathological hang with generous
+    # headroom.
+    timeout-minutes: 5
+    steps:
+      - name: Remove reserved label applied by an untrusted actor
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          LABEL_NAME: ${{ github.event.label.name }}
+        run: |
+          # GITHUB_EVENT_NAME is one of the default environment variables
+          # GitHub Actions sets for every step -- no need to declare it above.
+          if [ "$GITHUB_EVENT_NAME" = "pull_request_target" ]; then
+            gh pr edit "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --remove-label "$LABEL_NAME"
+          else
+            gh issue edit "$ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" --remove-label "$LABEL_NAME"
+          fi

--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -379,6 +379,38 @@ surface (comment minimization and a single evidence comment; no
 repository-content write). See the workflow file's own header comment
 for the full trust-model rationale.
 
+### `strip-untrusted-labels` workflow
+
+`.github/workflows/strip-untrusted-labels.yml` (added by issue #65,
+adapted from upstream `idd-skill`'s dogfooded
+`docs/customization.md#reserved-label-guard-recipe`) removes a reserved
+IDD label (the exact `roadmap` label, or any `status:*` label) the
+instant `coderabbitai[bot]` applies it to an issue or pull request —
+CodeRabbit auto-labels issues in this repository despite
+`.coderabbit.yaml`'s `issue_enrichment.labeling.auto_apply_labels:
+false` (confirmed by repeated reproduction in issue #65's history; a
+dashboard-level override is suspected to take precedence over the
+committed config), which would otherwise silently corrupt Discover's
+routing (a mislabeled `roadmap` on an execution child routes it into
+roadmap-audit handling instead of the normal claim path).
+
+It triggers on `issues: labeled` / `pull_request_target: labeled`,
+scoped by `github.event.sender.login` and `github.event.label.name` in
+the job `if:` — no repository content is ever checked out and no
+issue/PR-supplied content is executed, so a fork-originated
+`pull_request_target` label event is safe to act on with
+`issues: write` / `pull-requests: write` only. A human re-applying the
+same label afterward is a separate event whose actor does not match, so
+the guard never fights a genuine human decision. The actor list is
+scoped to `coderabbitai[bot]` only — this repository's
+`advisoryBotLogins` array also lists `copilot-pull-request-reviewer[bot]`
+and `chatgpt-codex-connector[bot]`, but a full repository-wide sweep of
+every `labeled` event in this repository's history found no label-write
+activity from either, so they are excluded pending actual evidence
+rather than copied from upstream's own (differently-scoped) hardcoded
+list. See the workflow file's own header comment for the full
+trust-model rationale and the evidence-sweep command.
+
 ### Worktree guard
 
 **Policy**: `worktreeGuard.enabled: true` in `.github/idd/config.json`.


### PR DESCRIPTION
Closes #65

## Summary

Adds `.github/workflows/strip-untrusted-labels.yml`, adapted from
upstream `idd-skill`'s own dogfooded reserved-label guard recipe
(`docs/customization.md#reserved-label-guard-recipe`): it removes a
reserved IDD label (`roadmap`, or any `status:*` label) the instant
`coderabbitai[bot]` applies it to an issue or pull request.

## Why this shape, not options 1/2

- **Option 1** (`.coderabbit.yaml`'s `auto_apply_labels: false`, PR
  #73) is already in place and stays, but is confirmed insufficient on
  its own: reproduced three times after merge (immediately, ~4h later,
  and again while authoring this issue's roadmap), `coderabbitai[bot]`
  re-applies `roadmap`/`status:*` within single-digit seconds every
  time — a dashboard-level override is the suspected cause, outside
  git's reach.
- **Option 2** (namespacing the label names) is unnecessarily
  disruptive now that it's technically unblocked (#48/#49 merged) —
  option 3 below neutralizes the effect regardless of where
  CodeRabbit's labeling decision originates, without renaming this
  repository's IDD control labels.
- **Option 3** (this PR): a same-event `issues: labeled` /
  `pull_request_target: labeled` guard, matching upstream's own
  dogfooded pattern for the identical problem.

## Actor-list scope

Upstream's own hardcoded list covers two bots
(`coderabbitai[bot]`, `chatgpt-codex-connector[bot]`). This
repository's `advisoryBotLogins` config array also lists both of those
plus Copilot's review bot, but a full repository-wide sweep of every
`labeled` event in this repository's history
(`GET /repos/{owner}/{repo}/issues/events`, every issue and PR, not a
recent sample) found label-write activity from only
`coderabbitai[bot]`. Neither Copilot's review bot nor
`chatgpt-codex-connector[bot]` has ever applied a label here, so
they're deliberately excluded pending actual evidence rather than
copied from upstream's differently-scoped list — see the workflow
file's own header comment for the full rationale and how to extend it
if that ever changes.

## Reserved-label set

The exact `roadmap` label, or any label whose name starts with
`status:` — this repository's distributed-default label names
(`.github/idd/config.json` has no `labels.*` override), which also
covers `status:authoring` per the issue's point 4 without a fourth
explicit check, matching upstream's own broader `startsWith` approach.

## Test plan

- [x] `pnpm run lint:fix` / `pnpm run lint` pass
- [x] `pnpm exec idd-doctor` passes (3 pre-existing warnings, unrelated
      to this change: post-merge cleanup backlog, release-tag drift,
      no required status checks on `main` — all tracked separately)
- [ ] Guard fires on a real `coderabbitai[bot]` mislabel event (verify
      after merge — this repository's own history shows CodeRabbit
      reliably mislabels within seconds of an issue create/edit, so a
      natural reproduction opportunity should arrive quickly; cannot
      self-test before merge since simulating the `coderabbitai[bot]`
      actor identity isn't available to this session)
- [ ] `gh issue list --state open --json number,labels --jq '.[] |
      select([.labels[].name] | index("roadmap")) | .number'` lists
      only genuine roadmap issues (already true today; re-check after
      the live-fire verification above)
