### PR TITLE
chore(root): drop the stale time-boxed babel override

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,10 +25,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  '@babel/parser': 7.29.7
-  '@babel/types': 7.29.7
-
 packageExtensionsChecksum: sha256-+IqWFRtcp34JmS6LMA9w4hWTD/XsSmmAt7J+Rz/azNc=
 
 pnpmfileChecksum: sha256-nVOmFZ6JT8FxIhcN+S5sJXuP1DtIhTre5ZGvjJU+4tk=

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,12 +8,6 @@ engineStrict: true
 gitChecks: false
 ignoreWorkspaceRootCheck: true
 linkWorkspacePackages: true
-# Time-boxed pnpm 11 minimumReleaseAge workaround: both patches clear the
-# 24h cutoff at 2026-08-01T15:07Z. Drop this override and re-resolve after
-# that, rather than carrying it indefinitely.
-overrides:
-  '@babel/parser': 7.29.7
-  '@babel/types': 7.29.7
 packageExtensions:
   undici-types:
     dependencies:


### PR DESCRIPTION
Closes #91

## Summary

Drops the time-boxed `@babel/parser`/`@babel/types` override in
`pnpm-workspace.yaml`, added as a workaround for pnpm 11's
`minimumReleaseAge` policy while landing #48/#49. Its own comment
named a 2026-08-01T15:07Z cutoff after which the pin should be
dropped; that cutoff has passed, and #50 (the issue expected to clear
it) merged without touching it — this was untracked technical debt.

## What changed

- Removed the `overrides` block (both entries) and its explanatory
  comment from `pnpm-workspace.yaml`.
- Ran `pnpm install` to re-resolve: both packages still naturally
  resolve to `7.29.7` without the pin — confirming it's no longer
  needed rather than just aging out silently. `pnpm-lock.yaml` only
  lost the now-redundant `overrides:` block itself; the resolved
  dependency tree is otherwise unchanged.

## Test plan

- [x] `pnpm run lint:fix` / `pnpm run lint` pass
- [x] `pnpm run build` passes
- [x] `pnpm run test` passes (68 tests, coverage unchanged)
