### PR TITLE
feat(docs): establish CHANGELOG.md format and release policy

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -274,6 +274,16 @@ it:
   `workspaceConcurrency: 1` (see `pnpm-workspace.yaml`) so that
   publish steps do not race; do not remove that setting
 
+### Release checklist
+
+- Before cutting a release, for every package that has `[Unreleased]`
+  entries in its `packages/<name>/CHANGELOG.md`, rename that heading to
+  `## [<version>] - <YYYY-MM-DD>` in the same pre-release change that
+  bumps `package.json` versions. A package a release did not touch
+  keeps no heading for that version — see the CHANGELOG Policy section
+  in [docs/idd-policy.md](../docs/idd-policy.md#changelog-policy) for
+  the full rule and its rationale.
+
 ## IDD Workflow
 
 This project uses Issue-Driven Development (IDD) with parallel AI

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -276,23 +276,24 @@ it:
 
 ### Release checklist
 
-- Before cutting a **stable** release, in the same pre-release change
-  that bumps `package.json` versions:
-  1. For every package the release actually changed, add an entry
-     under its `packages/<name>/CHANGELOG.md` `## [Unreleased]`
-     heading for each user-facing change since the last release.
-  2. For every touched package that now has `[Unreleased]` entries,
-     insert a new `## [<version>] - <YYYY-MM-DD>` heading below
-     `## [Unreleased]` and move those entries under it. Keep
-     `## [Unreleased]` in place, empty, for the next round — never
-     rename or remove it. A package the release did not touch keeps no
-     heading for that version.
-  - A **prerelease** cut (the `next` tag, e.g. `0.22.0-alpha.0`) does
-    not get its own heading — leave entries under `## [Unreleased]`
-    until the matching stable release cuts.
-  - See the CHANGELOG Policy section in
-    [docs/idd-policy.md](../docs/idd-policy.md#changelog-policy) for
-    the full rule and its rationale.
+- Before cutting **any** release (stable or prerelease), in the same
+  pre-release change that bumps `package.json` versions: for every
+  package the release actually changed, add an entry under its
+  `packages/<name>/CHANGELOG.md` `## [Unreleased]` heading for each
+  user-facing change since the last release.
+- Before cutting a **stable** release only, in that same change: for
+  every touched package that now has `[Unreleased]` entries, insert a
+  new `## [<version>] - <YYYY-MM-DD>` heading below `## [Unreleased]`
+  and move those entries under it. Keep `## [Unreleased]` in place,
+  empty, for the next round — never rename or remove it. A package the
+  release did not touch keeps no heading for that version.
+- A **prerelease** cut (the `next` tag, e.g. `0.22.0-alpha.0`) does not
+  get its own heading — its populated entries stay under
+  `## [Unreleased]` until the matching stable release cuts and moves
+  them.
+- See the CHANGELOG Policy section in
+  [docs/idd-policy.md](../docs/idd-policy.md#changelog-policy) for the
+  full rule and its rationale.
 
 ## IDD Workflow
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -277,12 +277,15 @@ it:
 ### Release checklist
 
 - Before cutting a release, for every package that has `[Unreleased]`
-  entries in its `packages/<name>/CHANGELOG.md`, rename that heading to
-  `## [<version>] - <YYYY-MM-DD>` in the same pre-release change that
-  bumps `package.json` versions. A package a release did not touch
-  keeps no heading for that version — see the CHANGELOG Policy section
-  in [docs/idd-policy.md](../docs/idd-policy.md#changelog-policy) for
-  the full rule and its rationale.
+  entries in its `packages/<name>/CHANGELOG.md`, insert a new
+  `## [<version>] - <YYYY-MM-DD>` heading below `## [Unreleased]` and
+  move those entries under it, in the same pre-release change that
+  bumps `package.json` versions. Keep `## [Unreleased]` in place,
+  empty, for the next round of entries — never rename or remove it. A
+  package a release did not touch keeps no heading for that version —
+  see the CHANGELOG Policy section in
+  [docs/idd-policy.md](../docs/idd-policy.md#changelog-policy) for the
+  full rule and its rationale.
 
 ## IDD Workflow
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -276,16 +276,23 @@ it:
 
 ### Release checklist
 
-- Before cutting a release, for every package that has `[Unreleased]`
-  entries in its `packages/<name>/CHANGELOG.md`, insert a new
-  `## [<version>] - <YYYY-MM-DD>` heading below `## [Unreleased]` and
-  move those entries under it, in the same pre-release change that
-  bumps `package.json` versions. Keep `## [Unreleased]` in place,
-  empty, for the next round of entries — never rename or remove it. A
-  package a release did not touch keeps no heading for that version —
-  see the CHANGELOG Policy section in
-  [docs/idd-policy.md](../docs/idd-policy.md#changelog-policy) for the
-  full rule and its rationale.
+- Before cutting a **stable** release, in the same pre-release change
+  that bumps `package.json` versions:
+  1. For every package the release actually changed, add an entry
+     under its `packages/<name>/CHANGELOG.md` `## [Unreleased]`
+     heading for each user-facing change since the last release.
+  2. For every touched package that now has `[Unreleased]` entries,
+     insert a new `## [<version>] - <YYYY-MM-DD>` heading below
+     `## [Unreleased]` and move those entries under it. Keep
+     `## [Unreleased]` in place, empty, for the next round — never
+     rename or remove it. A package the release did not touch keeps no
+     heading for that version.
+  - A **prerelease** cut (the `next` tag, e.g. `0.22.0-alpha.0`) does
+    not get its own heading — leave entries under `## [Unreleased]`
+    until the matching stable release cuts.
+  - See the CHANGELOG Policy section in
+    [docs/idd-policy.md](../docs/idd-policy.md#changelog-policy) for
+    the full rule and its rationale.
 
 ## IDD Workflow
 

--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -506,8 +506,13 @@ hook file invokes them changed.
   diverge in which version headings they contain, even though the
   version *numbers* they use stay shared across packages.
 - **Release-cut procedure**: in the same pre-release change that bumps
-  `package.json` versions, rename each touched package's
-  `## [Unreleased]` heading to `## [<version>] - <YYYY-MM-DD>`, for
-  every package that has `[Unreleased]` entries at that point. See the
-  matching step in the release checklist in
+  `package.json` versions, for every touched package that has
+  `[Unreleased]` entries at that point, insert a new
+  `## [<version>] - <YYYY-MM-DD>` heading directly below
+  `## [Unreleased]` and move those entries under it, then leave
+  `## [Unreleased]` in place, empty, ready for the next round of
+  entries. Never rename or remove the `## [Unreleased]` heading itself
+  — the file always keeps exactly one, or the next release has no
+  heading left to batch entries under. See the matching step in the
+  release checklist in
   [`.github/copilot-instructions.md`](../.github/copilot-instructions.md#release-checklist).

--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -478,3 +478,36 @@ rather than accepting the permanent false-positive warning:
 `lint-staged`'s and `commitlint`'s own configuration
 (`.lintstagedrc.mjs`, `.commitlintrc.yml`) are unchanged; only which
 hook file invokes them changed.
+
+## CHANGELOG Policy
+
+**Policy**: confirmed by the maintainer (`kurone-kito`) on 2026-08-10
+(issue #106).
+
+- **Format**: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
+  1.1.0. Each published package —
+  `@kurone-kito/sea-builder`, `@kurone-kito/typescript-config`, and
+  `@kurone-kito/vite-lib-config` — ships its own
+  `packages/<name>/CHANGELOG.md`, listed in that package's
+  `package.json` `files` array so it reaches the npm tarball (modern
+  npm does **not** auto-include `CHANGELOG.md` the way it does
+  `README*` / `LICENSE*` / `package.json`).
+- **Release-time-batch-only rule**: `CHANGELOG.md` entries are added
+  only as part of a release cut — never by an individual feature/fix
+  PR. This repository runs parallel IDD agents; if every PR edited a
+  shared `CHANGELOG.md`, `idd:discover-shared-file-overlap` would flag
+  every such PR as touching the same shared file, and concurrent claims
+  would collide on it.
+- **Per-package heading rule (lockstep versioning)**: the root and
+  every package share one version number, but a package's CHANGELOG
+  only gets a version heading for a release that actually changed that
+  package. A release that did not touch a given package does not get
+  an empty heading there — the three CHANGELOGs are expected to
+  diverge in which version headings they contain, even though the
+  version *numbers* they use stay shared across packages.
+- **Release-cut procedure**: in the same pre-release change that bumps
+  `package.json` versions, rename each touched package's
+  `## [Unreleased]` heading to `## [<version>] - <YYYY-MM-DD>`, for
+  every package that has `[Unreleased]` entries at that point. See the
+  matching step in the release checklist in
+  [`.github/copilot-instructions.md`](../.github/copilot-instructions.md#release-checklist).

--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -494,10 +494,13 @@ hook file invokes them changed.
   `README*` / `LICENSE*` / `package.json`).
 - **Release-time-batch-only rule**: `CHANGELOG.md` entries are added
   only as part of a release cut — never by an individual feature/fix
-  PR. This repository runs parallel IDD agents; if every PR edited a
-  shared `CHANGELOG.md`, `idd:discover-shared-file-overlap` would flag
-  every such PR as touching the same shared file, and concurrent claims
-  would collide on it.
+  PR. This repository runs parallel IDD agents, and every feature/fix
+  PR editing the same shared `CHANGELOG.md` would be ordinary Git merge
+  contention between concurrent branches — the `idd:discover-shared-
+  file-overlap` helper's own high-contention set (the review/merge
+  bundle files plus `audit/sync-manifest.json`) does not currently
+  cover package changelogs, so this rule's purpose is avoiding that
+  merge contention directly, not routing through that helper.
 - **Per-package heading rule (lockstep versioning)**: the root and
   every package share one version number, but a package's CHANGELOG
   only gets a version heading for a release that actually changed that
@@ -506,13 +509,26 @@ hook file invokes them changed.
   diverge in which version headings they contain, even though the
   version *numbers* they use stay shared across packages.
 - **Release-cut procedure**: in the same pre-release change that bumps
-  `package.json` versions, for every touched package that has
-  `[Unreleased]` entries at that point, insert a new
-  `## [<version>] - <YYYY-MM-DD>` heading directly below
-  `## [Unreleased]` and move those entries under it, then leave
-  `## [Unreleased]` in place, empty, ready for the next round of
-  entries. Never rename or remove the `## [Unreleased]` heading itself
-  — the file always keeps exactly one, or the next release has no
-  heading left to batch entries under. See the matching step in the
-  release checklist in
+  `package.json` versions:
+  1. For every package the release actually changed, add an entry
+     under its `## [Unreleased]` heading for each user-facing change
+     since the last release (source: the merged PRs in range, using
+     the same 🚀 Features / 🐛 Bug Fixes / 🧰 Maintenance categorization
+     `.github/release-drafter.yml` already applies).
+  2. For every touched package that now has `[Unreleased]` entries,
+     insert a new `## [<version>] - <YYYY-MM-DD>` heading directly
+     below `## [Unreleased]` and move those entries under it, then
+     leave `## [Unreleased]` in place, empty, ready for the next
+     round. Never rename or remove the `## [Unreleased]` heading
+     itself — the file always keeps exactly one, or the next release
+     has no heading left to batch entries under.
+  3. **Prerelease cuts** (`.github/workflows/release-next.yml`'s `next`
+     tag, versions like `0.22.0-alpha.0`) do **not** get their own
+     CHANGELOG heading — entries stay under `## [Unreleased]` through
+     every prerelease cut and only move under a version heading when
+     the corresponding **stable** release cuts, since a CHANGELOG
+     records user-facing release notes, not internal prerelease
+     iteration.
+
+  See the matching step in the release checklist in
   [`.github/copilot-instructions.md`](../.github/copilot-instructions.md#release-checklist).

--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -496,11 +496,12 @@ hook file invokes them changed.
   only as part of a release cut — never by an individual feature/fix
   PR. This repository runs parallel IDD agents, and every feature/fix
   PR editing the same shared `CHANGELOG.md` would be ordinary Git merge
-  contention between concurrent branches — the `idd:discover-shared-
-  file-overlap` helper's own high-contention set (the review/merge
-  bundle files plus `audit/sync-manifest.json`) does not currently
-  cover package changelogs, so this rule's purpose is avoiding that
-  merge contention directly, not routing through that helper.
+  contention between concurrent branches — the
+  `idd:discover-shared-file-overlap` helper's own high-contention set
+  (the review/merge bundle files plus `audit/sync-manifest.json`) does
+  not currently cover package changelogs, so this rule's purpose is
+  avoiding that merge contention directly, not routing through that
+  helper.
 - **Per-package heading rule (lockstep versioning)**: the root and
   every package share one version number, but a package's CHANGELOG
   only gets a version heading for a release that actually changed that

--- a/packages/sea-builder/CHANGELOG.md
+++ b/packages/sea-builder/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this
+project adheres to
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]

--- a/packages/sea-builder/package.json
+++ b/packages/sea-builder/package.json
@@ -23,6 +23,7 @@
     "sea-cache": "./dist/cache.mjs"
   },
   "files": [
+    "CHANGELOG.md",
     "dist"
   ],
   "scripts": {

--- a/packages/typescript-config/CHANGELOG.md
+++ b/packages/typescript-config/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this
+project adheres to
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]

--- a/packages/typescript-config/package.json
+++ b/packages/typescript-config/package.json
@@ -20,6 +20,7 @@
   "type": "module",
   "exports": "./tsconfig.json",
   "files": [
+    "CHANGELOG.md",
     "tsconfig.json"
   ],
   "scripts": {

--- a/packages/vite-lib-config/CHANGELOG.md
+++ b/packages/vite-lib-config/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this
+project adheres to
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]

--- a/packages/vite-lib-config/package.json
+++ b/packages/vite-lib-config/package.json
@@ -20,6 +20,7 @@
   "exports": "./dist/index.mjs",
   "types": "./dist/index.d.mts",
   "files": [
+    "CHANGELOG.md",
     "docs",
     "dist"
   ],


### PR DESCRIPTION
## Summary

- Add a Keep a Changelog-formatted `CHANGELOG.md` to `sea-builder`,
  `typescript-config`, and `vite-lib-config`, each starting with an
  empty `## [Unreleased]` heading
- List `CHANGELOG.md` in each package's `package.json` `files` array
  so it ships in the npm tarball (verified with `npm pack --dry-run`)
- Record the release-time-batch-only CHANGELOG policy, the per-package
  lockstep-versioning heading rule, and the release-cut rename
  procedure in `docs/idd-policy.md` and a new release checklist in
  `.github/copilot-instructions.md`

## Background

None of the three published packages ship a changelog today, even
though they are consumed as npm dependencies elsewhere, and modern npm
does not auto-include `CHANGELOG.md` in a tarball the way it does
`README*`/`LICENSE*`/`package.json`. This repository also runs
parallel IDD agents, so CHANGELOG edits are scoped to release-time
batch updates only (never per-PR) to avoid every feature/fix PR
colliding on the same shared file. This issue only scaffolds the
format and policy; the sibling issues #107/#108 backfill actual
history entries once this lands.

Closes #106


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added standardized changelogs for supported packages, including an **Unreleased** section.
  - Documented changelog formatting, release updates, package-specific headings, and release procedures.
  - Added references to Keep a Changelog and Semantic Versioning guidelines.
  - Added release checklist guidance for converting unreleased entries into versioned, dated headings.

- **Package Updates**
  - Changelogs are now included in published package contents for improved release visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->