### PR TITLE
chore(deps): align workspace typescript devDependencies to ~6.0.3

### DIFF
--- a/packages/example-cli/package.json
+++ b/packages/example-cli/package.json
@@ -42,7 +42,7 @@
     "@vitest/coverage-v8": "^4.1.0",
     "cpy-cli": "^7.0.0",
     "rimraf": "^6.0.1",
-    "typescript": "~5.9.3",
+    "typescript": "~6.0.3",
     "vite": "^7.1.9",
     "vitest": "^4.1.0",
     "xsea": "^0.1.1"

--- a/packages/example-lib/package.json
+++ b/packages/example-lib/package.json
@@ -37,7 +37,7 @@
     "@vitest/coverage-v8": "^4.1.0",
     "cpy-cli": "^7.0.0",
     "rimraf": "^6.0.1",
-    "typescript": "~5.9.3",
+    "typescript": "~6.0.3",
     "vite": "^7.1.9",
     "vitest": "^4.1.0"
   },

--- a/packages/sea-builder/package.json
+++ b/packages/sea-builder/package.json
@@ -52,7 +52,7 @@
     "cpy-cli": "^7.0.0",
     "rimraf": "^6.0.1",
     "type-fest": "^5.0.1",
-    "typescript": "~5.9.3",
+    "typescript": "~6.0.3",
     "vite": "^7.1.9",
     "vitest": "^4.1.0"
   },

--- a/packages/typescript-config/package.json
+++ b/packages/typescript-config/package.json
@@ -31,7 +31,7 @@
   "devDependencies": {
     "cpy-cli": "^7.0.0",
     "rimraf": "^6.0.1",
-    "typescript": "~5.9.3"
+    "typescript": "~6.0.3"
   },
   "peerDependencies": {
     "typescript": ">=5.7.x"

--- a/packages/vite-lib-config/package.json
+++ b/packages/vite-lib-config/package.json
@@ -50,7 +50,7 @@
     "rimraf": "^6.0.1",
     "typedoc": "^0.28.13",
     "typedoc-plugin-markdown": "^4.9.0",
-    "typescript": "~5.9.3",
+    "typescript": "~6.0.3",
     "vitest": "^4.1.0"
   },
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,8 +119,8 @@ importers:
         specifier: ^6.0.1
         version: 6.1.3
       typescript:
-        specifier: ~5.9.3
-        version: 5.9.3
+        specifier: ~6.0.3
+        version: 6.0.3
       vite:
         specifier: ^7.1.9
         version: 7.3.6(@types/node@24.13.3)(@types/picomatch@4.0.3)(jiti@2.6.1)(yaml@2.9.0)
@@ -149,8 +149,8 @@ importers:
         specifier: ^6.0.1
         version: 6.1.3
       typescript:
-        specifier: ~5.9.3
-        version: 5.9.3
+        specifier: ~6.0.3
+        version: 6.0.3
       vite:
         specifier: ^7.1.9
         version: 7.3.6(@types/node@24.13.3)(@types/picomatch@4.0.3)(jiti@2.6.1)(yaml@2.9.0)
@@ -201,8 +201,8 @@ importers:
         specifier: ^5.0.1
         version: 5.8.0
       typescript:
-        specifier: ~5.9.3
-        version: 5.9.3
+        specifier: ~6.0.3
+        version: 6.0.3
       vite:
         specifier: ^7.1.9
         version: 7.3.6(@types/node@24.13.3)(@types/picomatch@4.0.3)(jiti@2.6.1)(yaml@2.9.0)
@@ -219,8 +219,8 @@ importers:
         specifier: ^6.0.1
         version: 6.1.3
       typescript:
-        specifier: ~5.9.3
-        version: 5.9.3
+        specifier: ~6.0.3
+        version: 6.0.3
 
   packages/vite-lib-config:
     dependencies:
@@ -241,7 +241,7 @@ importers:
         version: 7.3.6(@types/node@24.13.3)(@types/picomatch@4.0.3)(jiti@2.6.1)(yaml@2.9.0)
       vite-plugin-dts:
         specifier: ^4.5.4
-        version: 4.5.4(@types/node@24.13.3)(rollup@4.62.3)(supports-color@8.1.1)(typescript@5.9.3)(vite@7.3.6(@types/node@24.13.3)(@types/picomatch@4.0.3)(jiti@2.6.1)(yaml@2.9.0))
+        version: 4.5.4(@types/node@24.13.3)(rollup@4.62.3)(supports-color@8.1.1)(typescript@6.0.3)(vite@7.3.6(@types/node@24.13.3)(@types/picomatch@4.0.3)(jiti@2.6.1)(yaml@2.9.0))
     devDependencies:
       '@kurone-kito/typescript-config':
         specifier: workspace:^
@@ -260,13 +260,13 @@ importers:
         version: 6.1.3
       typedoc:
         specifier: ^0.28.13
-        version: 0.28.20(typescript@5.9.3)
+        version: 0.28.20(typescript@6.0.3)
       typedoc-plugin-markdown:
         specifier: ^4.9.0
-        version: 4.12.0(typedoc@0.28.20(typescript@5.9.3))
+        version: 4.12.0(typedoc@0.28.20(typescript@6.0.3))
       typescript:
-        specifier: ~5.9.3
-        version: 5.9.3
+        specifier: ~6.0.3
+        version: 6.0.3
       vitest:
         specifier: ^4.1.0
         version: 4.1.10(@types/jsdom@28.0.3)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(vite@7.3.6(@types/node@24.13.3)(@types/picomatch@4.0.3)(jiti@2.6.1)(yaml@2.9.0))
@@ -3712,7 +3712,7 @@ snapshots:
       de-indent: 1.0.2
       he: 1.2.0
 
-  '@vue/language-core@2.2.0(typescript@5.9.3)':
+  '@vue/language-core@2.2.0(typescript@6.0.3)':
     dependencies:
       '@types/minimatch': 5.1.2
       '@types/path-browserify': 1.0.3
@@ -3725,7 +3725,7 @@ snapshots:
       muggle-string: 0.4.1
       path-browserify: 1.0.1
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
   '@vue/shared@3.5.40': {}
 
@@ -5030,11 +5030,11 @@ snapshots:
     dependencies:
       tagged-tag: 1.0.0
 
-  typedoc-plugin-markdown@4.12.0(typedoc@0.28.20(typescript@5.9.3)):
+  typedoc-plugin-markdown@4.12.0(typedoc@0.28.20(typescript@6.0.3)):
     dependencies:
-      typedoc: 0.28.20(typescript@5.9.3)
+      typedoc: 0.28.20(typescript@6.0.3)
 
-  typedoc@0.28.20(typescript@5.9.3):
+  typedoc@0.28.20(typescript@6.0.3):
     dependencies:
       '@gerrit0/mini-shiki': 3.23.0
       '@types/lunr': 2.3.7
@@ -5042,7 +5042,7 @@ snapshots:
       lunr: 2.3.9
       markdown-it: 14.3.0
       minimatch: 10.2.6
-      typescript: 5.9.3
+      typescript: 6.0.3
       yaml: 2.9.0
 
   typescript@5.9.3: {}
@@ -5067,19 +5067,19 @@ snapshots:
 
   universalify@2.0.1: {}
 
-  vite-plugin-dts@4.5.4(@types/node@24.13.3)(rollup@4.62.3)(supports-color@8.1.1)(typescript@5.9.3)(vite@7.3.6(@types/node@24.13.3)(@types/picomatch@4.0.3)(jiti@2.6.1)(yaml@2.9.0)):
+  vite-plugin-dts@4.5.4(@types/node@24.13.3)(rollup@4.62.3)(supports-color@8.1.1)(typescript@6.0.3)(vite@7.3.6(@types/node@24.13.3)(@types/picomatch@4.0.3)(jiti@2.6.1)(yaml@2.9.0)):
     dependencies:
       '@microsoft/api-extractor': 7.58.12(@types/node@24.13.3)
       '@rollup/pluginutils': 5.4.0(rollup@4.62.3)
       '@types/debug': 4.1.13
       '@volar/typescript': 2.4.28
-      '@vue/language-core': 2.2.0(typescript@5.9.3)
+      '@vue/language-core': 2.2.0(typescript@6.0.3)
       compare-versions: 6.1.1
       debug: 4.4.3(supports-color@8.1.1)
       kolorist: 1.8.0
       local-pkg: 1.2.1
       magic-string: 0.30.21
-      typescript: 5.9.3
+      typescript: 6.0.3
     optionalDependencies:
       vite: 7.3.6(@types/node@24.13.3)(@types/picomatch@4.0.3)(jiti@2.6.1)(yaml@2.9.0)
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary

- Bump `devDependencies.typescript` from `~5.9.3` to `~6.0.3` in all
  five workspace packages (`example-cli`, `example-lib`, `sea-builder`,
  `typescript-config`, `vite-lib-config`) to match the root
  `package.json`, which already pinned `~6.0.3`
- Refresh `pnpm-lock.yaml`
- Leave `typescript-config`'s `peerDependencies.typescript`
  (`>=5.7.x`) untouched — narrowing it is issue #111's concern, once
  this floor is in place

## Background

`typedoc@0.28.20` (pulled in via `vite-lib-config`) declares a
`typescript` peer of `6.0.3`, but the workspace resolved
`typescript@5.9.3` for it — `npm ls typescript --all` reported it
`invalid`. Verified before/after: `npm ls typescript --all` had 20
invalid entries on `main`, including the `typedoc` one; after this
change it's down to 17, and none reference `typedoc` anymore. The
remaining invalid entries are pre-existing, unrelated third-party
peer-range mismatches (e.g. `cosmiconfig-typescript-loader`,
`@microsoft/api-extractor` both declaring `^5.2.2`) outside this
issue's scope.

`pnpm run build`, `pnpm run lint`, and `pnpm run test` all pass under
TypeScript 6.0.3 — none of this repository's `tsconfig.json` files use
a setting TypeScript 6.0 deprecated.

Closes #110


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the TypeScript development tooling to version 6.0.3 across the project’s example applications, libraries, and build configuration packages.
  * No user-facing functionality or public APIs were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->