### PR TITLE
docs(changelog): backfill in-repo release history across all 3 packages

### DIFF
--- a/packages/sea-builder/CHANGELOG.md
+++ b/packages/sea-builder/CHANGELOG.md
@@ -45,8 +45,8 @@ project adheres to
 
 - Bumped the `listr2` dependency to `^9.0.4` (#19).
 - Bumped the `cpy-cli` devDependency to `^6.0.0`, `type-fest` to
-  `^5.0.1` (a major bump), `typescript` to `~5.9.3`, and `undici` to
-  `7.16.0` (#19).
+  `^5.0.1` (a major bump), `typescript` to `~5.9.3`, `undici` to
+  `7.16.0`, and `vite` to `^7.1.9` (#19).
 
 ## [0.20.0] - 2025-06-30
 

--- a/packages/sea-builder/CHANGELOG.md
+++ b/packages/sea-builder/CHANGELOG.md
@@ -18,7 +18,6 @@ project adheres to
 - Bumped the `cpy-cli` devDependency to v7 (#41).
 - Bumped the `semver` dependency to `^7.8.1` (#42).
 - Bumped dependencies via a grouped Dependabot update (#44).
-- Bumped the `undici` devDependency to v7.24.0 (#45).
 - Bumped the `undici` devDependency to v7.28.0 (#66).
 - Removed the unused, exact-pinned `undici` devDependency (#75).
 - **Breaking:** migrated the Node.js baseline from LTS Iron (v20) to
@@ -36,6 +35,12 @@ project adheres to
   permanent download cache (#72).
 - Stopped `devPreinstall` from executing unpinned `pnpm dlx` packages
   (#76).
+
+## [0.21.0] - 2025-10-03
+
+### Changed
+
+- Bumped the `listr2` dependency to `^9.0.4` (#19).
 
 ## [0.20.0] - 2025-06-30
 

--- a/packages/sea-builder/CHANGELOG.md
+++ b/packages/sea-builder/CHANGELOG.md
@@ -17,7 +17,8 @@ project adheres to
 
 - Bumped the `cpy-cli` devDependency to v7 (#41).
 - Bumped the `semver` dependency to `^7.8.1` (#42).
-- Bumped dependencies via a grouped Dependabot update (#44).
+- Bumped the `undici` devDependency to `7.24.0` and `vitest` to
+  `^4.1.0` (#44).
 - Bumped the `undici` devDependency to v7.28.0 (#66).
 - Removed the unused, exact-pinned `undici` devDependency (#75).
 - **Breaking:** raised the `engines.node` floor from
@@ -43,6 +44,9 @@ project adheres to
 ### Changed
 
 - Bumped the `listr2` dependency to `^9.0.4` (#19).
+- Bumped the `cpy-cli` devDependency to `^6.0.0`, `type-fest` to
+  `^5.0.1` (a major bump), `typescript` to `~5.9.3`, and `undici` to
+  `7.16.0` (#19).
 
 ## [0.20.0] - 2025-06-30
 

--- a/packages/sea-builder/CHANGELOG.md
+++ b/packages/sea-builder/CHANGELOG.md
@@ -20,8 +20,10 @@ project adheres to
 - Bumped dependencies via a grouped Dependabot update (#44).
 - Bumped the `undici` devDependency to v7.28.0 (#66).
 - Removed the unused, exact-pinned `undici` devDependency (#75).
-- **Breaking:** migrated the Node.js baseline from LTS Iron (v20) to
-  LTS Jod (v22), and pnpm to v11 (#88).
+- **Breaking:** raised the `engines.node` floor from
+  `^20.11 || ^22 || >=24` to `^22.23.1 || ^24.2.0 || >=26.0.0`,
+  dropping Node.js 20, Node.js 22 below 22.23.1, Node.js 24 below
+  24.2.0, and every Node.js 25 release; bumped pnpm to v11 (#88).
 - Bumped the `typescript` devDependency to `~6.0.3` (#113).
 
 ### Fixed

--- a/packages/sea-builder/CHANGELOG.md
+++ b/packages/sea-builder/CHANGELOG.md
@@ -8,3 +8,37 @@ project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Added
+
+- `CHANGELOG.md` (#112).
+
+### Changed
+
+- Bumped the `cpy-cli` devDependency to v7 (#41).
+- Bumped the `semver` dependency to `^7.8.1` (#42).
+- Bumped dependencies via a grouped Dependabot update (#44).
+- Bumped the `undici` devDependency to v7.24.0 (#45).
+- Bumped the `undici` devDependency to v7.28.0 (#66).
+- Removed the unused, exact-pinned `undici` devDependency (#75).
+- **Breaking:** migrated the Node.js baseline from LTS Iron (v20) to
+  LTS Jod (v22), and pnpm to v11 (#88).
+- Bumped the `typescript` devDependency to `~6.0.3` (#113).
+
+### Fixed
+
+- Restored CI signal on feature branches and pull requests, and
+  aligned the `@vitest/coverage-v8` peer with `vitest` v4 (#68).
+- Fixed the `env` shebang with a multi-word argument on Linux by
+  passing it with `-S` (#71).
+- Verified downloaded Node.js archives against their published
+  checksum before caching, and stopped writing directly into the
+  permanent download cache (#72).
+- Stopped `devPreinstall` from executing unpinned `pnpm dlx` packages
+  (#76).
+
+## [0.20.0] - 2025-06-30
+
+### Added
+
+- Initial release (#2).

--- a/packages/typescript-config/CHANGELOG.md
+++ b/packages/typescript-config/CHANGELOG.md
@@ -30,5 +30,5 @@ project adheres to
 
 ### Added
 
-- Migrated from `kurone-kito/lints-config`; its pre-migration history
-  will be backfilled in a follow-up (#108) (#2).
+- Migrated from `kurone-kito/lints-config` (#2); its pre-migration
+  history will be backfilled in a follow-up (#108).

--- a/packages/typescript-config/CHANGELOG.md
+++ b/packages/typescript-config/CHANGELOG.md
@@ -8,3 +8,27 @@ project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Added
+
+- `CHANGELOG.md` (#112).
+
+### Changed
+
+- Bumped the `cpy-cli` devDependency to v7 (#41).
+- **Breaking:** migrated the Node.js baseline from LTS Iron (v20) to
+  LTS Jod (v22), and pnpm to v11 (#88).
+- Bumped the `typescript` devDependency to `~6.0.3` (#113).
+
+## [0.21.0] - 2025-10-03
+
+### Changed
+
+- Improved the TypeScript configuration (#19).
+
+## [0.20.0] - 2025-06-30
+
+### Added
+
+- Migrated from `kurone-kito/lints-config`; see below for its history
+  prior to this release (#2).

--- a/packages/typescript-config/CHANGELOG.md
+++ b/packages/typescript-config/CHANGELOG.md
@@ -29,7 +29,10 @@ project adheres to
 - **Breaking:** enabled `erasableSyntaxOnly`, which rejects TypeScript
   syntax that requires emit-time transformation (enums, parameter
   properties, legacy `namespace`/`module` with runtime code, etc.)
-  (#19).
+  (#19). This option requires TypeScript 5.8+; the advertised
+  `peerDependencies` range (`>=5.7.x`) was not updated, so consumers
+  on TypeScript 5.7 must upgrade their compiler to avoid an unknown
+  compiler option error.
 - Bumped the `cpy-cli` devDependency to `^6.0.0` and `typescript` to
   `~5.9.3` (#19).
 

--- a/packages/typescript-config/CHANGELOG.md
+++ b/packages/typescript-config/CHANGELOG.md
@@ -30,6 +30,8 @@ project adheres to
   syntax that requires emit-time transformation (enums, parameter
   properties, legacy `namespace`/`module` with runtime code, etc.)
   (#19).
+- Bumped the `cpy-cli` devDependency to `^6.0.0` and `typescript` to
+  `~5.9.3` (#19).
 
 ## [0.20.0] - 2025-06-30
 

--- a/packages/typescript-config/CHANGELOG.md
+++ b/packages/typescript-config/CHANGELOG.md
@@ -30,5 +30,5 @@ project adheres to
 
 ### Added
 
-- Migrated from `kurone-kito/lints-config`; see below for its history
-  prior to this release (#2).
+- Migrated from `kurone-kito/lints-config`; its pre-migration history
+  will be backfilled in a follow-up (#108) (#2).

--- a/packages/typescript-config/CHANGELOG.md
+++ b/packages/typescript-config/CHANGELOG.md
@@ -24,7 +24,10 @@ project adheres to
 
 ### Changed
 
-- Improved the TypeScript configuration (#19).
+- **Breaking:** enabled `erasableSyntaxOnly`, which rejects TypeScript
+  syntax that requires emit-time transformation (enums, parameter
+  properties, legacy `namespace`/`module` with runtime code, etc.)
+  (#19).
 
 ## [0.20.0] - 2025-06-30
 

--- a/packages/typescript-config/CHANGELOG.md
+++ b/packages/typescript-config/CHANGELOG.md
@@ -16,8 +16,10 @@ project adheres to
 ### Changed
 
 - Bumped the `cpy-cli` devDependency to v7 (#41).
-- **Breaking:** migrated the Node.js baseline from LTS Iron (v20) to
-  LTS Jod (v22), and pnpm to v11 (#88).
+- **Breaking:** raised the `engines.node` floor from
+  `^20.11 || ^22 || >=24` to `^22.23.1 || ^24.2.0 || >=26.0.0`,
+  dropping Node.js 20, Node.js 22 below 22.23.1, Node.js 24 below
+  24.2.0, and every Node.js 25 release; bumped pnpm to v11 (#88).
 - Bumped the `typescript` devDependency to `~6.0.3` (#113).
 
 ## [0.21.0] - 2025-10-03

--- a/packages/vite-lib-config/CHANGELOG.md
+++ b/packages/vite-lib-config/CHANGELOG.md
@@ -21,6 +21,11 @@ project adheres to
   `^20.11 || ^22 || >=24` to `^22.23.1 || ^24.2.0 || >=26.0.0`,
   dropping Node.js 20, Node.js 22 below 22.23.1, Node.js 24 below
   24.2.0, and every Node.js 25 release; bumped pnpm to v11 (#88).
+- **Breaking:** raised the shared `viteConfig`'s Vite build target
+  from `node20.11` to `node22.23`. Any package built through this
+  config — including this repository's own `sea-builder` — may now
+  emit syntax unsupported on Node.js 20, even when the build itself
+  runs on a supported Node.js version (#88).
 - Bumped the `typescript` devDependency to `~6.0.3` (#113).
 
 ### Fixed

--- a/packages/vite-lib-config/CHANGELOG.md
+++ b/packages/vite-lib-config/CHANGELOG.md
@@ -32,8 +32,19 @@ project adheres to
 
 - Restored CI signal on feature branches and pull requests, and
   aligned the `@vitest/coverage-v8` peer with `vitest` v4 (#68).
-- Corrected published JSDoc that had the shebang and library-mode
-  build branches inverted (#70).
+- Corrected the published API documentation for `viteConfig` and
+  `vitestConfig`. `viteConfig`'s JSDoc had the shebang/library-mode
+  branches inverted and omitted that nonexistent entries are filtered
+  out first (an empty result after filtering yields an empty
+  configuration) and that a mixed set of entries falls into library
+  mode; `vitestConfig`'s JSDoc had incorrectly described the same
+  shebang/library-mode logic instead of its actual behavior — merging
+  a `test.environment: 'node'` default under the `viteConfig` built
+  for the same entry point (#70).
+- Resolved `typedoc-plugin-markdown` explicitly to avoid a lookup
+  failure under pnpm's global virtual store, and added external link
+  mappings for Vite's `UserConfig`/`mergeConfig` symbols in the
+  generated API docs (#88).
 
 ## [0.21.0] - 2025-10-03
 

--- a/packages/vite-lib-config/CHANGELOG.md
+++ b/packages/vite-lib-config/CHANGELOG.md
@@ -41,6 +41,12 @@ project adheres to
 
 - Added a TypeDoc-based API documentation generation pipeline (#19).
 
+### Changed
+
+- Bumped the `type-fest` dependency to `^5.0.1` (a major bump; used
+  by the exported `ViteConfigOptions` type) and `vite` to `^7.1.9`
+  (#19).
+
 ## [0.20.0] - 2025-06-30
 
 ### Added

--- a/packages/vite-lib-config/CHANGELOG.md
+++ b/packages/vite-lib-config/CHANGELOG.md
@@ -16,7 +16,7 @@ project adheres to
 ### Changed
 
 - Bumped the `cpy-cli` devDependency to v7 (#41).
-- Bumped dependencies via a grouped Dependabot update (#44).
+- Bumped the `vitest` devDependency to `^4.1.0` (#44).
 - **Breaking:** raised the `engines.node` floor from
   `^20.11 || ^22 || >=24` to `^22.23.1 || ^24.2.0 || >=26.0.0`,
   dropping Node.js 20, Node.js 22 below 22.23.1, Node.js 24 below
@@ -46,6 +46,8 @@ project adheres to
 - Bumped the `type-fest` dependency to `^5.0.1` (a major bump; used
   by the exported `ViteConfigOptions` type) and `vite` to `^7.1.9`
   (#19).
+- Bumped the `cpy-cli` devDependency to `^6.0.0` and `typescript` to
+  `~5.9.3` (#19).
 
 ## [0.20.0] - 2025-06-30
 

--- a/packages/vite-lib-config/CHANGELOG.md
+++ b/packages/vite-lib-config/CHANGELOG.md
@@ -8,3 +8,34 @@ project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Added
+
+- `CHANGELOG.md` (#112).
+
+### Changed
+
+- Bumped the `cpy-cli` devDependency to v7 (#41).
+- Bumped dependencies via a grouped Dependabot update (#44).
+- **Breaking:** migrated the Node.js baseline from LTS Iron (v20) to
+  LTS Jod (v22), and pnpm to v11 (#88).
+- Bumped the `typescript` devDependency to `~6.0.3` (#113).
+
+### Fixed
+
+- Restored CI signal on feature branches and pull requests, and
+  aligned the `@vitest/coverage-v8` peer with `vitest` v4 (#68).
+- Corrected published JSDoc that had the shebang and library-mode
+  build branches inverted (#70).
+
+## [0.21.0] - 2025-10-03
+
+### Added
+
+- Added a TypeDoc-based API documentation generation pipeline (#19).
+
+## [0.20.0] - 2025-06-30
+
+### Added
+
+- Initial release (#2).

--- a/packages/vite-lib-config/CHANGELOG.md
+++ b/packages/vite-lib-config/CHANGELOG.md
@@ -17,8 +17,10 @@ project adheres to
 
 - Bumped the `cpy-cli` devDependency to v7 (#41).
 - Bumped dependencies via a grouped Dependabot update (#44).
-- **Breaking:** migrated the Node.js baseline from LTS Iron (v20) to
-  LTS Jod (v22), and pnpm to v11 (#88).
+- **Breaking:** raised the `engines.node` floor from
+  `^20.11 || ^22 || >=24` to `^22.23.1 || ^24.2.0 || >=26.0.0`,
+  dropping Node.js 20, Node.js 22 below 22.23.1, Node.js 24 below
+  24.2.0, and every Node.js 25 release; bumped pnpm to v11 (#88).
 - Bumped the `typescript` devDependency to `~6.0.3` (#113).
 
 ### Fixed


### PR DESCRIPTION
## Summary

Backfill `sea-builder`, `typescript-config`, and `vite-lib-config`'s
`CHANGELOG.md` (scaffolded empty in #106) with every merged PR through
#113, classified deterministically:

1. Conventional Commits scope naming a target package.
2. Otherwise, the PR's changed-file paths under
   `packages/<target-package>/`.
3. A PR touching only `example-cli`/`example-lib`/no `packages/` path
   gets no entry (listed below).
4. A PR touching more than one target package's directory gets an
   entry in each.

The target range grew from the issue's original `#2`–`#104` to include
`#112`/`#113`, both merged after this issue was authored — re-verified
per the issue's own instruction before starting.

`typescript-config`'s `## [0.20.0]` section only records the
`lints-config` migration note, per #106's policy; its detailed
pre-migration history is issue #108's concern.

## Excluded

- #45 — no-op merge (empty diff against its first parent; the same
  `undici` bump had already landed via #44's grouped update by the
  time #45 merged)
- #39 — `chore(deps-dev)`, only `@kurone-kito/markdownlint-config` bump
- #40 — `chore(deps-dev)`, only `markdownlint-cli2` bump
- #47 — `chore(deps)`, only `actions/checkout`
- #73 — `fix(root)`, only `.coderabbit.yaml`
- #74 — `fix(ci)`, only the npmjs publish workflow
- #77 — `fix(ci)`, only Action SHA pinning
- #78 — `chore(deps)`, only `release-drafter/release-drafter`
- #79 — `chore(deps)`, only `actions/setup-node`
- #80 — `chore(deps)`, only `softprops/action-gh-release`
- #81 — `chore(deps)`, only `pnpm/action-setup`
- #82 — `chore(deps)`, only `actions/stale`
- #87 — `fix(root)`, only root `vitest`/lockfile
- #89 — `feat(root)`, IDD workflow template import
- #90 — `feat(root)`, IDD enforcement gates
- #98 — `chore(root)`, `idd-skill` pin bump
- #99 — `docs(root)`, IDD instruction reconciliation
- #100 — `feat(root)`, advisory-bot/CI-gate policy schema
- #101 — `ci(root)`, `idd-advisory-convergence` redesign
- #102 — `feat(root)`, strip untrusted IDD labels
- #104 — `chore(root)`, drop the stale babel override

## Acceptance criteria

- [x] Every PR in the range is accounted for (entry or exclusion above)
- [x] Each package's `CHANGELOG.md` has version headings only where it
      has entries for that release
- [x] `typescript-config`'s `## [0.20.0]` includes the migration note
- [x] `pnpm run lint` passes

Closes #107



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added unreleased changelog entries across project packages.
  - Documented updated Node.js and pnpm requirements, dependency upgrades, and configuration changes.
  - Recorded CI, coverage, archive verification, safer package execution, and published documentation improvements.
  - Clarified TypeScript and Vite updates, including documentation and build-target changes.
  - Added historical release notes for versions 0.20.0 and 0.21.0.
  - Preserved existing release history while improving visibility into recent fixes and enhancements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->