### PR TITLE
feat(typescript-config): refine tsconfig.json for typescript v7 readiness

### DIFF
--- a/packages/example-cli/tsconfig.json
+++ b/packages/example-cli/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "lib": ["DOM", "ES2023"],
+    "lib": ["DOM", "ES2024"],
     "noEmit": true,
     "rootDir": "src"
   },

--- a/packages/example-lib/tsconfig.json
+++ b/packages/example-lib/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "lib": ["DOM", "ES2023"],
+    "lib": ["DOM", "ES2024"],
     "noEmit": true,
     "rootDir": "src"
   },

--- a/packages/sea-builder/tsconfig.json
+++ b/packages/sea-builder/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "lib": ["DOM", "ES2023"],
+    "lib": ["DOM", "ES2024"],
     "noEmit": true,
     "rootDir": "src",
     "types": ["node"]

--- a/packages/typescript-config/README.md
+++ b/packages/typescript-config/README.md
@@ -8,7 +8,7 @@ My TypeScript configuration for general Node.js projects.
   - Jod LTS (`^22.23.1`)
   - Krypton LTS (`^24.2.0`)
   - Latest (`>=26.0.0`)
-- TypeScript: `>=5.7.x`
+- TypeScript: `>=7.0.0`
 
 ## Usage
 

--- a/packages/typescript-config/README.md
+++ b/packages/typescript-config/README.md
@@ -39,7 +39,7 @@ libraries:
 {
   "extends": "@kurone-kito/typescript-config",
   "compilerOptions": {
-    "lib": ["DOM", "ES2023"],
+    "lib": ["DOM", "ES2024"],
     "outDir": "dist",
     "rootDir": "src"
   },

--- a/packages/typescript-config/package.json
+++ b/packages/typescript-config/package.json
@@ -31,10 +31,10 @@
   "devDependencies": {
     "cpy-cli": "^7.0.0",
     "rimraf": "^6.0.1",
-    "typescript": "~6.0.3"
+    "typescript": "~7.0.2"
   },
   "peerDependencies": {
-    "typescript": ">=5.7.x"
+    "typescript": ">=7.0.0"
   },
   "peerDependenciesMeta": {
     "typescript": {

--- a/packages/typescript-config/tsconfig.json
+++ b/packages/typescript-config/tsconfig.json
@@ -7,10 +7,9 @@
     "checkJs": true,
     "composite": true,
     "declarationMap": true,
-    "esModuleInterop": true,
     "exactOptionalPropertyTypes": true,
     "isolatedModules": true,
-    "lib": ["ES2023"],
+    "lib": ["ES2024"],
     "module": "nodenext",
     "moduleResolution": "nodenext",
     "noEmitOnError": true,
@@ -26,10 +25,9 @@
     "resolveJsonModule": true,
     "rewriteRelativeImportExtensions": true,
     "sourceMap": true,
-    "strict": true,
     "stripInternal": true,
     "erasableSyntaxOnly": true,
-    "target": "ES2023",
+    "target": "ES2024",
     "verbatimModuleSyntax": true
   },
   "typeAcquisition": {

--- a/packages/vite-lib-config/tsconfig.json
+++ b/packages/vite-lib-config/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "lib": ["DOM", "ES2023"],
+    "lib": ["DOM", "ES2024"],
     "noEmit": true,
     "rootDir": "src",
     "types": ["node"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -219,8 +219,8 @@ importers:
         specifier: ^6.0.1
         version: 6.1.3
       typescript:
-        specifier: ~6.0.3
-        version: 6.0.3
+        specifier: ~7.0.2
+        version: 7.0.2
 
   packages/vite-lib-config:
     dependencies:
@@ -1285,6 +1285,126 @@ packages:
 
   '@types/yargs@17.0.35':
     resolution: {integrity: sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==}
+
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    resolution: {integrity: sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    resolution: {integrity: sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    resolution: {integrity: sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    resolution: {integrity: sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    resolution: {integrity: sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    resolution: {integrity: sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    resolution: {integrity: sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    resolution: {integrity: sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    resolution: {integrity: sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    resolution: {integrity: sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    resolution: {integrity: sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    resolution: {integrity: sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    resolution: {integrity: sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    resolution: {integrity: sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    resolution: {integrity: sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    resolution: {integrity: sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    resolution: {integrity: sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    resolution: {integrity: sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [win32]
 
   '@vitest/coverage-v8@4.1.10':
     resolution: {integrity: sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==}
@@ -2572,6 +2692,11 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  typescript@7.0.2:
+    resolution: {integrity: sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==}
+    engines: {node: '>=16.20.0'}
+    hasBin: true
+
   uc.micro@2.1.0:
     resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
 
@@ -3621,6 +3746,66 @@ snapshots:
   '@types/yargs@17.0.35':
     dependencies:
       '@types/yargs-parser': 21.0.3
+
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    optional: true
 
   '@vitest/coverage-v8@4.1.10(vitest@4.1.10)':
     dependencies:
@@ -5048,6 +5233,29 @@ snapshots:
   typescript@5.9.3: {}
 
   typescript@6.0.3: {}
+
+  typescript@7.0.2:
+    optionalDependencies:
+      '@typescript/typescript-aix-ppc64': 7.0.2
+      '@typescript/typescript-darwin-arm64': 7.0.2
+      '@typescript/typescript-darwin-x64': 7.0.2
+      '@typescript/typescript-freebsd-arm64': 7.0.2
+      '@typescript/typescript-freebsd-x64': 7.0.2
+      '@typescript/typescript-linux-arm': 7.0.2
+      '@typescript/typescript-linux-arm64': 7.0.2
+      '@typescript/typescript-linux-loong64': 7.0.2
+      '@typescript/typescript-linux-mips64el': 7.0.2
+      '@typescript/typescript-linux-ppc64': 7.0.2
+      '@typescript/typescript-linux-riscv64': 7.0.2
+      '@typescript/typescript-linux-s390x': 7.0.2
+      '@typescript/typescript-linux-x64': 7.0.2
+      '@typescript/typescript-netbsd-arm64': 7.0.2
+      '@typescript/typescript-netbsd-x64': 7.0.2
+      '@typescript/typescript-openbsd-arm64': 7.0.2
+      '@typescript/typescript-openbsd-x64': 7.0.2
+      '@typescript/typescript-sunos-x64': 7.0.2
+      '@typescript/typescript-win32-arm64': 7.0.2
+      '@typescript/typescript-win32-x64': 7.0.2
 
   uc.micro@2.1.0: {}
 


### PR DESCRIPTION
## Summary

Refine `packages/typescript-config/tsconfig.json` for TypeScript v7
readiness, per the issue's proposed change:

1. Deleted `"strict": true` and `"esModuleInterop": true` — both are
   mandatory, non-overridable defaults from TypeScript 6.0 onward, and
   #110 already put every internal consumer (`example-cli`,
   `example-lib`, `sea-builder`, `vite-lib-config`) on
   `typescript ~6.0.3`, so the deletion changes nothing observable for
   them.
2. Bumped `peerDependencies.typescript` from `>=5.7.x` to `>=7.0.0`
   and `devDependencies.typescript` from `~6.0.3` to `~7.0.2`
   (current `latest`). **Breaking** for any external consumer still on
   TypeScript <7 — same class of peer-mismatch warning this workspace
   already tolerates for `typedoc@0.28.20`, not a hard failure.
3. Bumped `target`/`lib` from `ES2023` to `ES2024` (investigation
   below).

## Investigation outcomes

### `target`/`lib` → `ES2024`

Checked whether every engine in `engines.node`'s full range
(`^22.23.1 || ^24.2.0 || >=26.0.0`) supports the runtime features
TypeScript 7's `lib.es2024.*.d.ts` exposes. The floor version,
Node.js `22.23.1`, is what this environment actually runs, so I
checked it directly rather than reasoning from release notes:

```console
$ node --version
v22.23.1
$ node -e "
console.log('Object.groupBy:', typeof Object.groupBy);
console.log('Map.groupBy:', typeof Map.groupBy);
console.log('Promise.withResolvers:', typeof Promise.withResolvers);
console.log('ArrayBuffer.prototype.transfer:', typeof ArrayBuffer.prototype.transfer);
console.log('String.prototype.isWellFormed:', typeof String.prototype.isWellFormed);
"
Object.groupBy: function
Map.groupBy: function
Promise.withResolvers: function
ArrayBuffer.prototype.transfer: function
String.prototype.isWellFormed: function
```

All present on the range's floor version. Node.js `24.2.0` and
`26.0.0` ship strictly newer V8 releases, so they carry every feature
the floor already has. Compiling a file that calls all of the above
under `typescript@7.0.2` with `target`/`lib: "ES2024"` type-checks
with zero errors. **Decision: bumped to `ES2024`.**

### `noErrorTruncation` / `preserveWatchOutput`

Both vanish from `tsc --showConfig`'s output under `typescript@7.0.2`
(confirmed, matching the issue's own finding), but `--showConfig` only
echoes options that were explicitly set somewhere in the config
chain — it does **not** enumerate implicit defaults at all (verified
with a bare `{}` tsconfig: `--showConfig` reports `"compilerOptions": {}"`,
even though TypeScript still applies `strict: true` etc. during an
actual compile). So the vanished `--showConfig` entry doesn't imply
the option itself stopped working; I tested actual behavior instead:

- `noErrorTruncation`: compiled a file that produces a message long
  enough to truncate. Without the option, `typescript@7.0.2` truncates
  with `...`; with `"noErrorTruncation": true`, the full type is
  printed untruncated. **Still takes effect.**
- `preserveWatchOutput`: ran `tsc -w` under `typescript@7.0.2` and
  captured raw bytes. Without the option, each recompilation is
  preceded by `\x1b[2J\x1b[3J\x1b[H` (clear screen + clear scrollback +
  cursor home); with `"preserveWatchOutput": true`, those escape codes
  are absent and output is only appended. **Still takes effect.**

**Decision: kept both.**

## Acceptance-criteria note on `--showConfig`

The issue's last acceptance-criteria bullet expected
`pnpm --filter @kurone-kito/typescript-config exec tsc --showConfig`
against a consuming file to still show `strict: true` and
`esModuleInterop: true` after the deletions, as proof TypeScript 7
supplies both as mandatory defaults. As found above, `--showConfig`
does not enumerate implicit defaults at all (verified with a bare `{}`
config under `typescript@7.0.2` — `compilerOptions` reports empty).
Both keys are absent from the resolved `--showConfig` output after
this change, exactly as they would be for *any* unset option,
regardless of TypeScript version.

The underlying claim — that TypeScript 7 still enforces both as
non-overridable defaults — is verified instead by actual compile
behavior:

- `const v: string | null = null; v.length;` still errors `TS18047`
  ('possibly null') under `typescript@7.0.2` with no `strict` set
  anywhere in the config.
- `"esModuleInterop": false` still hard-errors `TS5108` ("Option
  'esModuleInterop=false' has been removed") under the same version.

## Test plan

- [x] `pnpm run lint` passes
- [x] `pnpm run build` succeeds across the workspace
- [x] `pnpm run test` passes (68/68 tests, including
      `test:ts`'s workspace-wide `tsc --noEmit`)
- [x] `packages/typescript-config/tsconfig.json` no longer contains
      `strict` or `esModuleInterop`
- [x] `peerDependencies.typescript` is `>=7.0.0`;
      `devDependencies.typescript` is `~7.0.2`

Closes #111


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated TypeScript tooling and compilation settings to support the latest language standards.
  * Improved compatibility with ES2024 features and modern TypeScript projects.
  * No changes to the product’s public functionality or user-facing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->