### PR TITLE
docs(changelog): backfill typescript-config's pre-migration history

### DIFF
--- a/packages/typescript-config/CHANGELOG.md
+++ b/packages/typescript-config/CHANGELOG.md
@@ -41,4 +41,508 @@ project adheres to
 ### Added
 
 - Migrated from `kurone-kito/lints-config` (#2); its pre-migration
-  history will be backfilled in a follow-up (#108).
+  history (`0.1.2`–`0.19.0`) is recorded below.
+
+## [0.19.0] - 2025-06-08
+
+_Released as part of
+[kurone-kito/lints-config@v0.19.0](https://github.com/kurone-kito/lints-config/releases/tag/v0.19.0)
+before this package migrated to this repository._
+
+### Added
+
+- Added the `lib: ["ES2023"]` compiler option
+  (kurone-kito/lints-config#111).
+
+### Changed
+
+- Bumped `target` from `ES2022` to `ES2023`
+  (kurone-kito/lints-config#111).
+
+## [0.18.0] - 2025-05-20
+
+_Released as part of
+[kurone-kito/lints-config@v0.18.0](https://github.com/kurone-kito/lints-config/releases/tag/v0.18.0)
+before this package migrated to this repository._
+
+### Added
+
+- Added the `rimraf` devDependency (`^6.0.1`)
+  (kurone-kito/lints-config#110).
+
+### Removed
+
+- Removed the `typescript-eslint-language-service` compiler plugin
+  entry from `tsconfig.json`, and dropped `@typescript-eslint/parser`,
+  `eslint`, and `typescript-eslint-language-service` — both peer and
+  dev — along with the matching README install-command line
+  (kurone-kito/lints-config#110).
+
+### Changed
+
+- **Breaking:** raised the `engines.node` floor from
+  `^18.20 || ^20.10 || >=22` to `^20.11 || >=22`, dropping Node.js 18
+  (kurone-kito/lints-config#110).
+
+## [0.17.3] - 2024-12-15
+
+_Released as part of
+[kurone-kito/lints-config@v0.17.3](https://github.com/kurone-kito/lints-config/releases/tag/v0.17.3)
+before this package migrated to this repository._
+
+### Changed
+
+- Maintenance update; no functional change to this package
+  (kurone-kito/lints-config#109).
+
+## [0.17.2] - 2024-12-14
+
+_Released as part of
+[kurone-kito/lints-config@v0.17.2](https://github.com/kurone-kito/lints-config/releases/tag/v0.17.2)
+before this package migrated to this repository._
+
+### Removed
+
+- Removed the `concurrently` devDependency, no longer needed now that
+  `prepack` runs `pnpm run clean && pnpm run build` directly instead
+  of via Yarn and `concurrently` (kurone-kito/lints-config#108).
+
+### Changed
+
+- Bumped the `@typescript-eslint/parser` peer/devDependency range to
+  `>=8.x.x`, the `typescript` devDependency to `~5.7.2`, and `eslint`
+  to `^9.17.0` (kurone-kito/lints-config#108).
+
+## [0.16.1] - 2024-09-09
+
+_Released as part of
+[kurone-kito/lints-config@v0.16.1](https://github.com/kurone-kito/lints-config/releases/tag/v0.16.1)
+before this package migrated to this repository._
+
+### Changed
+
+- Raised the `engines.node` floor from `>=18` to
+  `^18.20 || ^20.10 || >=22` (kurone-kito/lints-config#92).
+
+## [0.16.0] - 2024-08-20
+
+_Released as part of
+[kurone-kito/lints-config@v0.16.0](https://github.com/kurone-kito/lints-config/releases/tag/v0.16.0)
+before this package migrated to this repository._
+
+### Changed
+
+- Maintenance update; no functional change to this package
+  (kurone-kito/lints-config#91).
+
+## [0.15.0] - 2024-08-17
+
+_Released as part of
+[kurone-kito/lints-config@v0.15.0](https://github.com/kurone-kito/lints-config/releases/tag/v0.15.0)
+before this package migrated to this repository._
+
+### Changed
+
+- Maintenance update; no functional change to this package
+  (kurone-kito/lints-config#90).
+
+## [0.14.0] - 2024-08-04
+
+_Released as part of
+[kurone-kito/lints-config@v0.14.0](https://github.com/kurone-kito/lints-config/releases/tag/v0.14.0)
+before this package migrated to this repository._
+
+### Added
+
+- Added `@typescript-eslint/parser` as a peer dependency
+  (`>=6.x.x`, optional) (kurone-kito/lints-config#89).
+
+### Removed
+
+- Removed Prettier entirely from this package's own dev tooling: the
+  top-level `prettier` config-pointer field, the shared
+  `@kurone-kito/prettier-config` devDependency, and the `prettier`
+  devDependency itself (kurone-kito/lints-config#89).
+
+### Changed
+
+- Bumped the devDependency `@typescript-eslint/parser` to `^8.0.0`
+  and `typescript` to `~5.5.4` (kurone-kito/lints-config#89).
+
+## [0.13.0] - 2024-07-16
+
+_Released as part of
+[kurone-kito/lints-config@v0.13.0](https://github.com/kurone-kito/lints-config/releases/tag/v0.13.0)
+before this package migrated to this repository._
+
+### Changed
+
+- **Breaking:** narrowed the `typescript` peer dependency range from
+  `>=4.7.x` to `>=5.x.x`, dropping TypeScript 4.x support
+  (kurone-kito/lints-config#87).
+- Removed the `newLine: "LF"` compiler option and bumped
+  `@typescript-eslint/parser` to `^7.16.1` and `typescript` to
+  `~5.5.3` (kurone-kito/lints-config#87).
+
+## [0.12.0] - 2024-06-19
+
+_Released as part of
+[kurone-kito/lints-config@v0.12.0](https://github.com/kurone-kito/lints-config/releases/tag/v0.12.0)
+before this package migrated to this repository._
+
+### Changed
+
+- Reworked the release scripts: added a `build` script
+  (`cpy "../../LICENSE" "typescript-config/LICENSE"`) and changed
+  `prepack` to run it via `concurrently`; bumped
+  `@typescript-eslint/parser` to `^7.13.1`
+  (kurone-kito/lints-config#80).
+
+## [0.11.1] - 2024-06-07
+
+_Released as part of
+[kurone-kito/lints-config@v0.11.1](https://github.com/kurone-kito/lints-config/releases/tag/v0.11.1)
+before this package migrated to this repository._
+
+### Changed
+
+- Bumped the `@typescript-eslint/parser` devDependency to `^7.12.0`
+  and `prettier` to `^3.3.1` (kurone-kito/lints-config#79).
+
+## [0.11.0] - 2024-05-13
+
+_Released as part of
+[kurone-kito/lints-config@v0.11.0](https://github.com/kurone-kito/lints-config/releases/tag/v0.11.0)
+before this package migrated to this repository._
+
+### Changed
+
+- Bumped the `@typescript-eslint/parser` devDependency to `^7.8.0`
+  and `typescript` to `~5.4.5` (kurone-kito/lints-config#73).
+
+## [0.10.0] - 2024-04-13
+
+_Released as part of
+[kurone-kito/lints-config@v0.9.1](https://github.com/kurone-kito/lints-config/releases/tag/v0.9.1)
+before this package migrated to this repository. The git tag and
+GitHub Release are both named `v0.9.1`, but the published
+`package.json` version — and the npm registry — say `0.10.0`; this
+heading follows what was actually published._
+
+### Removed
+
+- Removed the redundant `module: "tsconfig.json"` field from
+  `package.json` (kurone-kito/lints-config#66).
+
+### Changed
+
+- Bumped the `@typescript-eslint/parser` devDependency to `^7.6.0`
+  and `typescript` to `~5.4.4` (kurone-kito/lints-config#66).
+
+## [0.9.0] - 2024-03-14
+
+_Released as part of
+[kurone-kito/lints-config@v0.9.0](https://github.com/kurone-kito/lints-config/releases/tag/v0.9.0)
+before this package migrated to this repository._
+
+### Changed
+
+- Bumped the `@typescript-eslint/parser` devDependency to `^7.2.0`,
+  `prettier` to `^3.2.5`, and `typescript` to `~5.4.2`
+  (kurone-kito/lints-config#61, kurone-kito/lints-config#62,
+  kurone-kito/lints-config#64, kurone-kito/lints-config#65).
+
+## [0.8.4] - 2023-12-05
+
+_Released as part of
+[kurone-kito/lints-config@v0.8.4](https://github.com/kurone-kito/lints-config/releases/tag/v0.8.4)
+before this package migrated to this repository._
+
+### Changed
+
+- Version bump only; no functional change to this package
+  (kurone-kito/lints-config#60).
+
+## [0.8.3] - 2023-12-05
+
+_Released as part of
+[kurone-kito/lints-config@v0.8.3](https://github.com/kurone-kito/lints-config/releases/tag/v0.8.3)
+before this package migrated to this repository. This version was
+never published to the npm registry (only `0.8.2` and `0.8.4` are
+present); dated from the git tag rather than an npm publish
+timestamp._
+
+### Changed
+
+- Bumped the `@typescript-eslint/parser` devDependency to `^6.13.2`
+  (kurone-kito/lints-config#59).
+
+## [0.8.2] - 2023-12-03
+
+_Released as part of
+[kurone-kito/lints-config@v0.8.2](https://github.com/kurone-kito/lints-config/releases/tag/v0.8.2)
+before this package migrated to this repository._
+
+### Changed
+
+- Reworked the `clean` script's argument order; bumped the
+  `@typescript-eslint/parser` devDependency to `^6.13.1`, `eslint` to
+  `^8.55.0`, `prettier` to `^3.1.0`, and `typescript` to `~5.3.2`
+  (kurone-kito/lints-config#58).
+
+## [0.8.1] - 2023-11-12
+
+_Released as part of
+[kurone-kito/lints-config@v0.8.1](https://github.com/kurone-kito/lints-config/releases/tag/v0.8.1)
+before this package migrated to this repository._
+
+### Added
+
+- Added an explicit `"license": "MIT"` field to `package.json`
+  (kurone-kito/lints-config#57).
+
+### Changed
+
+- Bumped the `@typescript-eslint/parser` devDependency to `^6.10.0`
+  and `eslint` to `^8.53.0` (kurone-kito/lints-config#57).
+
+## [0.8.0] - 2023-10-21
+
+_Released as part of
+[kurone-kito/lints-config@v0.8.0](https://github.com/kurone-kito/lints-config/releases/tag/v0.8.0)
+before this package migrated to this repository._
+
+### Changed
+
+- Bumped the `@typescript-eslint/parser` devDependency to `^6.8.0` and
+  `eslint` to `^8.52.0` (kurone-kito/lints-config#56).
+
+## [0.7.6] - 2023-10-05
+
+_Released as part of
+[kurone-kito/lints-config@v0.7.6](https://github.com/kurone-kito/lints-config/releases/tag/v0.7.6)
+before this package migrated to this repository._
+
+### Added
+
+- Added a `prepack` script that copies the repository's `LICENSE`
+  file into the package via the new `cpy-cli` devDependency
+  (kurone-kito/lints-config#55).
+
+### Changed
+
+- Bumped the `@typescript-eslint/parser` devDependency to `^6.7.4` and
+  `eslint` to `^8.50.0` (kurone-kito/lints-config#55).
+
+## [0.7.5] - 2023-09-21
+
+_Released as part of
+[kurone-kito/lints-config@v0.7.5](https://github.com/kurone-kito/lints-config/releases/tag/v0.7.5)
+before this package migrated to this repository._
+
+### Changed
+
+- **Breaking:** raised the `engines.node` floor from `>=16.20` to
+  `>=18`, dropping Node.js 16 (kurone-kito/lints-config#49).
+- Bumped the `@typescript-eslint/parser` devDependency to `^6.7.2`,
+  `eslint` to `^8.49.0`, and `prettier` to `^3.0.3`
+  (kurone-kito/lints-config#49).
+
+## [0.7.4] - 2023-08-25
+
+_Released as part of
+[kurone-kito/lints-config@v0.7.4](https://github.com/kurone-kito/lints-config/releases/tag/v0.7.4)
+before this package migrated to this repository._
+
+### Added
+
+- Added explicit `exports` map entries for `.` and `./tsconfig.json`,
+  and a `module` field, both pointing at `tsconfig.json`
+  (kurone-kito/lints-config#43).
+
+### Changed
+
+- Bumped the `@typescript-eslint/parser` devDependency to `^6.4.1`,
+  `eslint` to `^8.47.0`, `prettier` to `^3.0.2`, and `typescript` to
+  `~5.2.2` (kurone-kito/lints-config#43).
+
+## [0.7.3] - 2023-08-11
+
+_Released as part of
+[kurone-kito/lints-config@v0.7.3](https://github.com/kurone-kito/lints-config/releases/tag/v0.7.3)
+before this package migrated to this repository._
+
+### Changed
+
+- Bumped the `@typescript-eslint/parser` devDependency to `^6.3.0`,
+  `eslint` to `^8.46.0`, and `prettier` to `^3.0.1`
+  (kurone-kito/lints-config#42).
+
+## [0.7.2] - 2023-07-28
+
+_Released as part of
+[kurone-kito/lints-config@v0.7.2](https://github.com/kurone-kito/lints-config/releases/tag/v0.7.2)
+before this package migrated to this repository._
+
+### Changed
+
+- Version bump only; no functional change to this package
+  (kurone-kito/lints-config#36).
+
+## [0.7.1] - 2023-07-27
+
+_Released as part of
+[kurone-kito/lints-config@v0.7.1](https://github.com/kurone-kito/lints-config/releases/tag/v0.7.1)
+before this package migrated to this repository. This release also
+folded in the untagged `0.7.0` version bump._
+
+### Changed
+
+- Bumped the `@typescript-eslint/parser` devDependency from `^5.60.0`
+  to `^6.2.0`, `eslint` to `^8.45.0`, `prettier` from `^2.8.8` to
+  `^3.0.0`, and `typescript` to `~5.1.6`
+  (kurone-kito/lints-config#34, kurone-kito/lints-config#35).
+
+## [0.6.0] - 2023-06-22
+
+_Released as part of
+[kurone-kito/lints-config@v0.6.0](https://github.com/kurone-kito/lints-config/releases/tag/v0.6.0)
+before this package migrated to this repository._
+
+### Changed
+
+- Relaxed the `typescript` and `typescript-eslint-language-service`
+  peer dependencies from exact-pinned versions to `>=4.7.x` and
+  `>=5.x.x`, and marked both `optional` via `peerDependenciesMeta`
+  (kurone-kito/lints-config#25).
+- Bumped the `@typescript-eslint/parser` devDependency to `^5.60.0`
+  and `eslint` to `^8.43.0` (kurone-kito/lints-config#25).
+
+## [0.5.0] - 2023-06-10
+
+_Released as part of
+[kurone-kito/lints-config@v0.5.0](https://github.com/kurone-kito/lints-config/releases/tag/v0.5.0)
+before this package migrated to this repository._
+
+### Changed
+
+- Bumped the `@typescript-eslint/parser` devDependency to `^5.59.9`,
+  `eslint` to `^8.42.0`, and `typescript` to `~5.1.3`
+  (kurone-kito/lints-config#18, kurone-kito/lints-config#19).
+
+## [0.4.0] - 2023-05-24
+
+_Released as part of
+[kurone-kito/lints-config@v0.4.0](https://github.com/kurone-kito/lints-config/releases/tag/v0.4.0)
+before this package migrated to this repository._
+
+### Changed
+
+- **Breaking:** raised the `target` compiler option from `ES2019` to
+  `ES2022` (kurone-kito/lints-config#16, kurone-kito/lints-config#17).
+- Bumped the `@typescript-eslint/parser` devDependency to `^5.59.7`
+  and `eslint` to `^8.41.0` (kurone-kito/lints-config#16).
+
+## [0.3.3] - 2023-05-06
+
+_Released as part of
+[kurone-kito/lints-config@v0.3.3](https://github.com/kurone-kito/lints-config/releases/tag/v0.3.3)
+before this package migrated to this repository. This release also
+folded in the untagged `0.3.1` and `0.3.2` version bumps._
+
+### Changed
+
+- Reformatted the README's install command onto multiple lines;
+  bumped the `@typescript-eslint/parser` devDependency to `^5.59.2`
+  and `eslint` to `^8.40.0` (kurone-kito/lints-config#13,
+  kurone-kito/lints-config#14, kurone-kito/lints-config#15).
+
+## [0.3.0] - 2023-04-24
+
+_Released as part of
+[kurone-kito/lints-config@v0.3.0](https://github.com/kurone-kito/lints-config/releases/tag/v0.3.0)
+before this package migrated to this repository._
+
+### Changed
+
+- **Breaking:** raised the `engines.node` floor from `>=14.21` to
+  `>=16.20`, dropping Node.js 14 (kurone-kito/lints-config#12).
+- Bumped the `@typescript-eslint/parser` devDependency to `^5.59.1`
+  and `prettier` to `^2.8.8` (kurone-kito/lints-config#12).
+
+## [0.2.8] - 2023-04-22
+
+_Released as part of
+[kurone-kito/lints-config@v0.2.8](https://github.com/kurone-kito/lints-config/releases/tag/v0.2.8)
+before this package migrated to this repository._
+
+### Changed
+
+- Bumped the `@typescript-eslint/parser` devDependency to `^5.59.0`
+  and `typescript` to `~5.0.4` (kurone-kito/lints-config#11).
+
+## [0.2.7] - 2023-04-07
+
+_Released as part of
+[kurone-kito/lints-config@v0.2.7](https://github.com/kurone-kito/lints-config/releases/tag/v0.2.7)
+before this package migrated to this repository. This release also
+folded in the untagged `0.2.1`, `0.2.5`, and `0.2.6` version bumps,
+which fixed a broken `publishConfig` that had blocked public npm
+publishing since `0.2.0` (kurone-kito/lints-config#8,
+kurone-kito/lints-config#9); the first version that installs from npm
+in this range is `0.2.5`._
+
+### Changed
+
+- Flipped `publishConfig.access` from `restricted` to `public`,
+  making this package installable from the public npm registry for
+  the first time (kurone-kito/lints-config#8,
+  kurone-kito/lints-config#9).
+- Added a `clean` script; bumped the `@typescript-eslint/parser`
+  devDependency to `^5.57.1`, `typescript` to `~5.0.3`, and
+  `typescript-eslint-language-service` to `^5.0.5`
+  (kurone-kito/lints-config#4, kurone-kito/lints-config#10).
+
+## [0.2.0] - 2023-03-29
+
+_Released as part of
+[kurone-kito/lints-config@v0.2.0](https://github.com/kurone-kito/lints-config/releases/tag/v0.2.0)
+before this package migrated to this repository. This version was
+never successfully published to the npm registry — a broken
+`publishConfig` blocked every publish attempt in this range until it
+was fixed in the `0.2.7` range above; nobody could `npm install` this
+exact version._
+
+### Added
+
+- Enabled `allowJs`, `checkJs`, `composite`,
+  `exactOptionalPropertyTypes`, `isolatedModules`, `noEmitOnError`,
+  `noErrorTruncation`, `noUnusedLocals`, `preserveValueImports`, and
+  `stripInternal`; enabled `typeAcquisition.enable`
+  (kurone-kito/lints-config#3).
+
+### Changed
+
+- Switched `module`/`moduleResolution` from `ESNext`/`node` to
+  `nodenext`; bumped the `@typescript-eslint/parser` devDependency to
+  `^5.57.0`, `eslint` to `^8.37.0`, `prettier` to `^2.8.7`, and
+  `typescript-eslint-language-service` to `^5.0.3`
+  (kurone-kito/lints-config#3).
+
+### Removed
+
+- Removed `declaration`, `emitDecoratorMetadata`, and
+  `experimentalDecorators` (kurone-kito/lints-config#3).
+
+## [0.1.2] - 2023-03-22
+
+_Released as part of
+[kurone-kito/lints-config@v0.1.2](https://github.com/kurone-kito/lints-config/releases/tag/v0.1.2)
+before this package migrated to this repository._
+
+### Added
+
+- Initial release: a `tsconfig.json` extending base with a
+  `typescript-eslint-language-service` compiler plugin, `strict`
+  compiler options, `target: "ES2019"`, and a `typescript` peer
+  dependency pinned to `~5.0.2` (kurone-kito/lints-config#2).

--- a/packages/typescript-config/CHANGELOG.md
+++ b/packages/typescript-config/CHANGELOG.md
@@ -416,9 +416,9 @@ before this package migrated to this repository._
 ### Changed
 
 - Relaxed the `typescript` and `typescript-eslint-language-service`
-  peer dependencies from exact-pinned versions to `>=4.7.x` and
-  `>=5.x.x`, and marked both `optional` via `peerDependenciesMeta`
-  (kurone-kito/lints-config#25).
+  peer dependencies from the narrow ranges `~5.1.3` and `^5.0.5` to
+  the broad `>=4.7.x` and `>=5.x.x`, and marked both `optional` via
+  `peerDependenciesMeta` (kurone-kito/lints-config#25).
 - Bumped the `@typescript-eslint/parser` devDependency to `^5.60.0`
   and `eslint` to `^8.43.0` (kurone-kito/lints-config#25).
 
@@ -438,7 +438,8 @@ before this package migrated to this repository._
 
 _Released as part of
 [kurone-kito/lints-config@v0.4.0](https://github.com/kurone-kito/lints-config/releases/tag/v0.4.0)
-before this package migrated to this repository._
+before this package migrated to this repository. This release also
+folded in the untagged `0.3.4` version bump._
 
 ### Changed
 

--- a/packages/typescript-config/CHANGELOG.md
+++ b/packages/typescript-config/CHANGELOG.md
@@ -486,11 +486,13 @@ before this package migrated to this repository._
 _Released as part of
 [kurone-kito/lints-config@v0.2.7](https://github.com/kurone-kito/lints-config/releases/tag/v0.2.7)
 before this package migrated to this repository. This release also
-folded in the untagged `0.2.1`, `0.2.5`, and `0.2.6` version bumps,
-which fixed a broken `publishConfig` that had blocked public npm
-publishing since `0.2.0` (kurone-kito/lints-config#8,
-kurone-kito/lints-config#9); the first version that installs from npm
-in this range is `0.2.5`._
+folded in the untagged `0.2.1`, `0.2.4`, `0.2.5`, and `0.2.6` version
+bumps, which fixed a broken `publishConfig` that had blocked public
+npm publishing since `0.2.0` (kurone-kito/lints-config#8,
+kurone-kito/lints-config#9); `0.2.4` was itself a failed publish
+attempt during that fix (lints-config's own release for `0.2.5` is
+titled "0.2.5: Republish"), and the first version that actually
+installs from npm in this range is `0.2.5`._
 
 ### Changed
 
@@ -536,13 +538,17 @@ exact version._
 
 ## [0.1.2] - 2023-03-22
 
-_Released as part of
+_Earliest git-tagged release, as part of
 [kurone-kito/lints-config@v0.1.2](https://github.com/kurone-kito/lints-config/releases/tag/v0.1.2)
-before this package migrated to this repository._
+before this package migrated to this repository. The package was
+first published as `0.1.0` (2023-03-21), an untagged version with no
+distinct package.json commit of its own; this entry's content covers
+everything since the package's introduction
+(kurone-kito/lints-config#2)._
 
 ### Added
 
-- Initial release: a `tsconfig.json` extending base with a
+- Introduced the package: a `tsconfig.json` extending base with a
   `typescript-eslint-language-service` compiler plugin, `strict`
   compiler options, `target: "ES2019"`, and a `typescript` peer
   dependency pinned to `~5.0.2` (kurone-kito/lints-config#2).

--- a/packages/typescript-config/CHANGELOG.md
+++ b/packages/typescript-config/CHANGELOG.md
@@ -79,7 +79,7 @@ before this package migrated to this repository._
   `typescript-eslint-language-service` from both `peerDependencies`
   and `devDependencies`, and `eslint` from `devDependencies` only (it
   was never a peer dependency); also removed the matching README
-  install-command line (kurone-kito/lints-config#110).
+  install command line (kurone-kito/lints-config#110).
 
 ### Changed
 
@@ -558,7 +558,7 @@ _Earliest git-tagged release, as part of
 [kurone-kito/lints-config@v0.1.2](https://github.com/kurone-kito/lints-config/releases/tag/v0.1.2)
 before this package migrated to this repository. The package was
 first published as `0.1.0` (2023-03-21), an untagged version with no
-distinct package.json commit of its own; this entry's content covers
+distinct `package.json` commit of its own; this entry's content covers
 everything since the package's introduction
 (kurone-kito/lints-config#2)._
 

--- a/packages/typescript-config/CHANGELOG.md
+++ b/packages/typescript-config/CHANGELOG.md
@@ -49,13 +49,15 @@ _Released as part of
 [kurone-kito/lints-config@v0.19.0](https://github.com/kurone-kito/lints-config/releases/tag/v0.19.0)
 before this package migrated to this repository._
 
-### Added
-
-- Added the `lib: ["ES2023"]` compiler option
-  (kurone-kito/lints-config#111).
-
 ### Changed
 
+- **Breaking:** added an explicit `lib: ["ES2023"]` compiler option.
+  TypeScript replaces its default library set with an explicit `lib`
+  array rather than augmenting it, so consumers who don't override
+  `lib` themselves lose the `DOM`/`DOM.Iterable`/`ScriptHost` globals
+  (`window`, `document`, `fetch`, etc.) that `target`'s default
+  inference had been including; such consumers must now add `DOM`
+  explicitly if they need it (kurone-kito/lints-config#111).
 - Bumped `target` from `ES2022` to `ES2023`
   (kurone-kito/lints-config#111).
 
@@ -73,10 +75,11 @@ before this package migrated to this repository._
 ### Removed
 
 - Removed the `typescript-eslint-language-service` compiler plugin
-  entry from `tsconfig.json`, and dropped `@typescript-eslint/parser`,
-  `eslint`, and `typescript-eslint-language-service` — both peer and
-  dev — along with the matching README install-command line
-  (kurone-kito/lints-config#110).
+  entry from `tsconfig.json`. Dropped `@typescript-eslint/parser` and
+  `typescript-eslint-language-service` from both `peerDependencies`
+  and `devDependencies`, and `eslint` from `devDependencies` only (it
+  was never a peer dependency); also removed the matching README
+  install-command line (kurone-kito/lints-config#110).
 
 ### Changed
 
@@ -109,9 +112,10 @@ before this package migrated to this repository._
 
 ### Changed
 
-- Bumped the `@typescript-eslint/parser` peer/devDependency range to
-  `>=8.x.x`, the `typescript` devDependency to `~5.7.2`, and `eslint`
-  to `^9.17.0` (kurone-kito/lints-config#108).
+- Bumped the `@typescript-eslint/parser` peerDependency range to
+  `>=8.x.x` and its devDependency to `^8.18.0`, the `typescript`
+  devDependency to `~5.7.2`, and `eslint` to `^9.17.0`
+  (kurone-kito/lints-config#108).
 
 ## [0.16.1] - 2024-09-09
 

--- a/packages/typescript-config/CHANGELOG.md
+++ b/packages/typescript-config/CHANGELOG.md
@@ -362,14 +362,15 @@ _Released as part of
 [kurone-kito/lints-config@v0.7.4](https://github.com/kurone-kito/lints-config/releases/tag/v0.7.4)
 before this package migrated to this repository._
 
-### Added
-
-- Added explicit `exports` map entries for `.` and `./tsconfig.json`,
-  and a `module` field, both pointing at `tsconfig.json`
-  (kurone-kito/lints-config#43).
-
 ### Changed
 
+- **Breaking:** added an explicit `exports` map restricting resolvable
+  subpaths to `.` and `./tsconfig.json` only (both pointing at
+  `tsconfig.json`), and a `module` field pointing at the same file.
+  Node.js rejects any other subpath import (e.g.
+  `@kurone-kito/typescript-config/package.json`) with
+  `ERR_PACKAGE_PATH_NOT_EXPORTED` once an `exports` map is present,
+  where it previously resolved (kurone-kito/lints-config#43).
 - Bumped the `@typescript-eslint/parser` devDependency to `^6.4.1`,
   `eslint` to `^8.47.0`, `prettier` to `^3.0.2`, and `typescript` to
   `~5.2.2` (kurone-kito/lints-config#43).
@@ -517,9 +518,10 @@ installs from npm in this range is `0.2.5`._
 
 ### Removed
 
-- Removed `forceConsistentCasingInFileNames`, `importsNotUsedAsValues`,
-  `incremental`, and `preserveValueImports`, all added in the `0.2.0`
-  range above (kurone-kito/lints-config#10).
+- Removed `forceConsistentCasingInFileNames` and `incremental` (both
+  present since `0.1.2`), and `importsNotUsedAsValues` and
+  `preserveValueImports` (both added in the `0.2.0` range above)
+  (kurone-kito/lints-config#10).
 
 ## [0.2.0] - 2023-03-29
 

--- a/packages/typescript-config/CHANGELOG.md
+++ b/packages/typescript-config/CHANGELOG.md
@@ -85,6 +85,7 @@ before this package migrated to this repository._
 
 - **Breaking:** raised the `engines.node` floor from
   `^18.20 || ^20.10 || >=22` to `^20.11 || >=22`, dropping Node.js 18
+  and the previously-supported Node.js 20.10 line
   (kurone-kito/lints-config#110).
 
 ## [0.17.3] - 2024-12-15
@@ -125,8 +126,10 @@ before this package migrated to this repository._
 
 ### Changed
 
-- Raised the `engines.node` floor from `>=18` to
-  `^18.20 || ^20.10 || >=22` (kurone-kito/lints-config#92).
+- **Breaking:** raised the `engines.node` floor from `>=18` to
+  `^18.20 || ^20.10 || >=22`, dropping Node.js 18 below 18.20, every
+  Node.js 19 release, Node.js 20 below 20.10, and every Node.js 21
+  release (kurone-kito/lints-config#92).
 
 ## [0.16.0] - 2024-08-20
 
@@ -347,7 +350,8 @@ before this package migrated to this repository._
 ### Changed
 
 - **Breaking:** raised the `engines.node` floor from `>=16.20` to
-  `>=18`, dropping Node.js 16 (kurone-kito/lints-config#49).
+  `>=18`, dropping Node.js 16 and every Node.js 17 release
+  (kurone-kito/lints-config#49).
 - Bumped the `@typescript-eslint/parser` devDependency to `^6.7.2`,
   `eslint` to `^8.49.0`, and `prettier` to `^3.0.3`
   (kurone-kito/lints-config#49).
@@ -471,7 +475,8 @@ before this package migrated to this repository._
 ### Changed
 
 - **Breaking:** raised the `engines.node` floor from `>=14.21` to
-  `>=16.20`, dropping Node.js 14 (kurone-kito/lints-config#12).
+  `>=16.20`, dropping Node.js 14, every Node.js 15 release, and
+  Node.js 16 below 16.20 (kurone-kito/lints-config#12).
 - Bumped the `@typescript-eslint/parser` devDependency to `^5.59.1`
   and `prettier` to `^2.8.8` (kurone-kito/lints-config#12).
 
@@ -510,6 +515,12 @@ installs from npm in this range is `0.2.5`._
   `typescript-eslint-language-service` to `^5.0.5`
   (kurone-kito/lints-config#4, kurone-kito/lints-config#10).
 
+### Removed
+
+- Removed `forceConsistentCasingInFileNames`, `importsNotUsedAsValues`,
+  `incremental`, and `preserveValueImports`, all added in the `0.2.0`
+  range above (kurone-kito/lints-config#10).
+
 ## [0.2.0] - 2023-03-29
 
 _Released as part of
@@ -523,10 +534,10 @@ exact version._
 ### Added
 
 - Enabled `allowJs`, `checkJs`, `composite`,
-  `exactOptionalPropertyTypes`, `isolatedModules`, `noEmitOnError`,
-  `noErrorTruncation`, `noUnusedLocals`, `preserveValueImports`, and
-  `stripInternal`; enabled `typeAcquisition.enable`
-  (kurone-kito/lints-config#3).
+  `exactOptionalPropertyTypes`, `importsNotUsedAsValues: "error"`,
+  `isolatedModules`, `noEmitOnError`, `noErrorTruncation`,
+  `noUnusedLocals`, `preserveValueImports`, and `stripInternal`;
+  enabled `typeAcquisition.enable` (kurone-kito/lints-config#3).
 
 ### Changed
 
@@ -556,4 +567,4 @@ everything since the package's introduction
 - Introduced the package: a `tsconfig.json` extending base with a
   `typescript-eslint-language-service` compiler plugin, `strict`
   compiler options, `target: "ES2019"`, and a `typescript` peer
-  dependency pinned to `~5.0.2` (kurone-kito/lints-config#2).
+  dependency set to the narrow range `~5.0.2` (kurone-kito/lints-config#2).


### PR DESCRIPTION
## Summary

Backfills `packages/typescript-config/CHANGELOG.md` with 34 version
headings (`0.1.2` through `0.19.0`) below the existing `0.20.0`
section, covering every git-tagged
[kurone-kito/lints-config](https://github.com/kurone-kito/lints-config)
release that touched `packages/typescript-config` from its 2023-03-11
introduction (per #107's own investigation) through its migration to
this repository in #2.

Also reworded `0.20.0`'s migration note, which said the pre-migration
history "will be backfilled in a follow-up (#108)" — now that #108
exists, that line pointed at itself and would go stale the moment this
merges.

## Methodology

Cloned `lints-config` locally and walked
`packages/typescript-config/package.json`'s own version-history
commit-by-commit — the most granular, unambiguous ground truth for
what that package's manifest actually said at each point. Cross-checked
against `npm view @kurone-kito/typescript-config time --json` (the
package's actual publish history) and each release's PR body/diff
before writing an entry, rather than trusting any single source.

This surfaced real discrepancies between the git tag surface and what
was actually published, all documented inline at the affected
headings:

- **`v0.9.1` → headed as `0.10.0`.** The git tag and its GitHub
  Release are both named `v0.9.1`, but the `package.json` version bump
  inside that range — and the npm registry — both say `0.10.0`. Used
  what was actually published, not the tag name.
- **`v0.2.0` was git-tagged but never successfully published.** A
  broken `publishConfig` blocked every npm publish attempt from
  `v0.2.0` through the untagged `0.2.1`/`0.2.4` bumps, until it was
  fixed and republished as `0.2.5` (npm's own release for that fix is
  literally titled "0.2.5: Republish") within the `v0.2.7` range.
  `v0.2.0` keeps its own heading (it's git-tagged, per the issue's
  "every release tag" criterion) with a note that it was never
  actually installable. `0.2.1`/`0.2.4` were never git-tagged, so they
  don't get their own headings — they're folded into the `v0.2.7`
  entry's note.
- **`v0.8.3` is tagged but absent from the npm registry** (`npm view
  @kurone-kito/typescript-config@0.8.3` 404s, jumping straight from
  `0.8.2` to `0.8.4`). Dated from the git tag rather than a publish
  timestamp, with a note.

## Breaking-change verification

Every `!`-marked commit in lints-config's history that touched this
package was checked against its **actual diff** for this package
specifically, not assumed breaking from the commit subject alone (the
`!` on a monorepo-wide commit can be breaking for one package and not
another). Four more entries are marked **Breaking:** without a
`!`-marked source commit, since each is observably breaking for
consumers on its own regardless of how the source commit was labeled:
`0.4.0`'s `target` bump, `0.7.4`'s `exports` map addition, `0.16.1`'s
`engines.node` narrowing, and `0.19.0`'s explicit `lib` addition.
Eight are genuinely breaking for `typescript-config` consumers and are
marked **Breaking:**:

- `0.3.0` — dropped Node.js 14, every Node.js 15 release, and Node.js
  16 below 16.20 (`engines.node` `>=14.21` → `>=16.20`)
- `0.4.0` — raised `target` from `ES2019` to `ES2022`, crossing
  several syntax-introducing ECMAScript versions (optional chaining,
  nullish coalescing, top-level await, class fields); consumers'
  compiled output may now assume runtime features an ES2019 target
  wouldn't have required
- `0.7.4` — added an explicit `exports` map restricting resolvable
  subpaths to `.` and `./tsconfig.json`; Node.js rejects any other
  subpath import (e.g. the package's own `package.json`) with
  `ERR_PACKAGE_PATH_NOT_EXPORTED` once an `exports` map is present,
  where it previously resolved
- `0.7.5` — dropped Node.js 16 and every Node.js 17 release
  (`>=16.20` → `>=18`)
- `0.13.0` — narrowed the `typescript` peer range `>=4.7.x` → `>=5.x.x`
- `0.16.1` — dropped Node.js 18 below 18.20, every Node.js 19 release,
  Node.js 20 below 20.10, and every Node.js 21 release (`engines.node`
  `>=18` → `^18.20 || ^20.10 || >=22`)
- `0.18.0` — dropped Node.js 18 and the previously-supported Node.js
  20.10 line (`^18.20 || ^20.10 || >=22` → `^20.11 || >=22`)
- `0.19.0` — added an explicit `lib: ["ES2023"]`, which *replaces*
  TypeScript's default library set rather than augmenting it; any
  consumer not already overriding `lib` loses the `DOM`/
  `DOM.Iterable`/`ScriptHost` globals that `target`'s default
  inference had been including

By contrast, `0.19.0`'s separate `target` bump (`ES2022` → `ES2023`)
is **not** itself marked breaking: ES2023 added only library
(`lib.d.ts`) surface (`Array.prototype.toSorted` and similar), no new
syntax requiring runtime support beyond what ES2022 already assumed —
the `lib` addition in the same release is what's actually breaking.

Two `!`-marked commits touching this package were checked and found
**not** breaking for it specifically, so they're recorded as ordinary
`Changed` entries without the marker:

- `0.6.0`'s `chore(ALL)!: relaxed peer-dependent version requirements`
  — relaxed `typescript`/`typescript-eslint-language-service` peers
  from exact pins to `>=4.7.x`/`>=5.x.x` and made both optional; a
  relaxation is backward-compatible, not breaking.
- `0.7.1`-era's `chore(ALL)!: added, removed, and updated the
  dependencies` — the only typescript-config-specific changes were
  devDependency-only major bumps (`@typescript-eslint/parser` v5→v6,
  `prettier` v2→v3), neither of which was a peer dependency at that
  point.

## Excluded

- `0.1.0` — the package's very first npm-published version (before
  its first git tag `v0.1.2`); no distinct git-tagged state exists for
  it. `v0.1.2`'s entry notes this and covers everything since the
  package's actual introduction.
- `0.2.1`, `0.2.4` — untagged intermediate bumps during the broken-
  publish period, folded into the `v0.2.7` entry's note (updated after
  Codex flagged `0.2.4`'s initial omission there).
- `0.3.1`, `0.3.2` — untagged intermediate bumps folded into the
  `v0.3.3` entry.
- `0.3.4` — untagged intermediate bump folded into the `v0.4.0` entry
  (chronologically between the `v0.3.3` and `v0.4.0` tags, not the
  `v0.3.3` entry — corrected after an earlier draft of this section
  misattributed it).
- `0.7.0` — untagged, folded into the `v0.7.1` entry.
- `0.17.0`, `0.17.1` — only alpha prereleases of these ever shipped
  (`0.17.0-alpha.1`–`.5`, `0.17.1-alpha.1`); no stable release exists,
  consistent with this repository's own prerelease-carveout policy
  (`docs/idd-policy.md#changelog-policy`).
- All other `-alpha.N` versions throughout, for the same reason.

## Acceptance criteria

- [x] Every `lints-config` release tag between the package's
      introduction and `v0.19.0` that touched
      `packages/typescript-config` has a corresponding version heading
      (or a documented reason it doesn't, above)
- [x] All headings sit below the existing `0.20.0` section, newest
      first
- [x] The earliest heading (`0.1.2`) notes the package's original
      introduction
- [x] `pnpm run lint` passes

Closes #108


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive historical changelog entries covering versions 0.19.0 through 0.1.2.
  * Documented compatibility updates, tooling changes, compiler options, package metadata, migrations, additions, removals, and publishing history.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

