### PR TITLE
docs(security): route reports to private vulnerability reporting

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,12 +14,16 @@
 
 ## Reporting a Vulnerability
 
-If you discover a security vulnerability within this project, please report
-it by issuing a
-[pull request with a fix](https://github.com/kurone-kito/builder-config/pulls)
-or
-[opening an issue](https://github.com/kurone-kito/builder-config/issues)
-with the “security” label.
+If you discover a security vulnerability within this project, please
+report it privately using GitHub's
+[private vulnerability reporting](https://github.com/kurone-kito/builder-config/security/advisories/new)
+form, rather than a public issue or pull request. This gives us a
+private channel to confirm the issue and prepare a fix before any
+details become public.
+
+As noted above, we do not provide a security SLA for community users,
+so please don't expect a guaranteed response time — but your report
+will be reviewed.
 
 Your contributions to improving the security of this project are greatly
 appreciated.


### PR DESCRIPTION
## Summary

Replaces `SECURITY.md`'s "Reporting a Vulnerability" section so it
points at GitHub's private vulnerability reporting form instead of
telling reporters to open a public pull request or issue.

## Background

The previous text routed vulnerability reports through two public
channels — a pull request with a fix, or an issue tagged `security`
(a label that never existed in this repository, confirmed via
`gh label list`). Both disclose the flaw before a release carries the
patch, which defeats the purpose for a repository publishing three
packages to the public npm registry.

#62 confirmed the private channel is actually live
(`gh api repos/kurone-kito/builder-config/private-vulnerability-reporting`
→ `{"enabled":true}`) and recorded the decision to drop the `security`
label reference entirely rather than create the label, since the new
text doesn't route through public issues at all.

## Changes

- Primary route is now the
  [private vulnerability reporting form](https://github.com/kurone-kito/builder-config/security/advisories/new).
- Removed the instruction to open a public issue or pull request.
- Dropped the `security` label reference.
- Added a line setting expectations (no guaranteed response time,
  consistent with the existing "Community users" section right above
  it) so the new text doesn't promise an SLA the repository doesn't
  provide.
- "Community users" section is untouched (verified byte-identical via
  `git diff`).

## Test plan

- [x] `SECURITY.md` no longer instructs public issue/PR reporting.
- [x] Private reporting route has a working link to this repository's
      own advisory form.
- [x] No `security` label is referenced anywhere in the file.
- [x] "Community users" section byte-identical (only the "Reporting a
      Vulnerability" section changed — see the diff).
- [x] `pnpm run lint` clean (markdownlint + cspell cover this file).

Closes #63


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the vulnerability reporting process to use GitHub’s private reporting form.
  * Clarified that submissions are reviewed, without guaranteeing a response timeframe.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->