### PR TITLE
chore(deps): align typescript devDependency to ~7.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "markdownlint-cli2": "^0.23.0",
     "rimraf": "^6.0.1",
     "semver": "^7.8.1",
-    "typescript": "~6.0.3",
+    "typescript": "~7.0.2",
     "vitest": "^4.1.0"
   },
   "packageManager": "pnpm@11.15.1+sha512.81350b07e53c9538a02f1f2303b4290fa2d7be04e56e2a970c4cc4b417dc761de196edabd49d55c7dc9580db81007c44143e4e3d7e462b3000d23c255122d065",

--- a/packages/example-cli/package.json
+++ b/packages/example-cli/package.json
@@ -42,7 +42,7 @@
     "@vitest/coverage-v8": "^4.1.0",
     "cpy-cli": "^7.0.0",
     "rimraf": "^6.0.1",
-    "typescript": "~6.0.3",
+    "typescript": "~7.0.2",
     "vite": "^7.1.9",
     "vitest": "^4.1.0",
     "xsea": "^0.1.1"

--- a/packages/example-lib/package.json
+++ b/packages/example-lib/package.json
@@ -37,7 +37,7 @@
     "@vitest/coverage-v8": "^4.1.0",
     "cpy-cli": "^7.0.0",
     "rimraf": "^6.0.1",
-    "typescript": "~6.0.3",
+    "typescript": "~7.0.2",
     "vite": "^7.1.9",
     "vitest": "^4.1.0"
   },

--- a/packages/sea-builder/package.json
+++ b/packages/sea-builder/package.json
@@ -53,7 +53,7 @@
     "cpy-cli": "^7.0.0",
     "rimraf": "^6.0.1",
     "type-fest": "^5.0.1",
-    "typescript": "~6.0.3",
+    "typescript": "~7.0.2",
     "vite": "^7.1.9",
     "vitest": "^4.1.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,7 +38,7 @@ importers:
         version: 2.5.6
       '@commitlint/cli':
         specifier: ^21.2.0
-        version: 21.2.1(@types/node@24.13.3)(conventional-commits-parser@7.1.1)(typescript@6.0.3)
+        version: 21.2.1(@types/node@24.13.3)(conventional-commits-parser@7.1.1)(typescript@7.0.2)
       '@commitlint/config-conventional':
         specifier: ^21.2.0
         version: 21.2.0
@@ -88,8 +88,8 @@ importers:
         specifier: ^7.8.1
         version: 7.8.5
       typescript:
-        specifier: ~6.0.3
-        version: 6.0.3
+        specifier: ~7.0.2
+        version: 7.0.2
       vitest:
         specifier: ^4.1.0
         version: 4.1.10(@types/jsdom@28.0.3)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(vite@7.3.6(@types/node@24.13.3)(@types/picomatch@4.0.3)(jiti@2.6.1)(yaml@2.9.0))
@@ -119,8 +119,8 @@ importers:
         specifier: ^6.0.1
         version: 6.1.3
       typescript:
-        specifier: ~6.0.3
-        version: 6.0.3
+        specifier: ~7.0.2
+        version: 7.0.2
       vite:
         specifier: ^7.1.9
         version: 7.3.6(@types/node@24.13.3)(@types/picomatch@4.0.3)(jiti@2.6.1)(yaml@2.9.0)
@@ -149,8 +149,8 @@ importers:
         specifier: ^6.0.1
         version: 6.1.3
       typescript:
-        specifier: ~6.0.3
-        version: 6.0.3
+        specifier: ~7.0.2
+        version: 7.0.2
       vite:
         specifier: ^7.1.9
         version: 7.3.6(@types/node@24.13.3)(@types/picomatch@4.0.3)(jiti@2.6.1)(yaml@2.9.0)
@@ -204,8 +204,8 @@ importers:
         specifier: ^5.0.1
         version: 5.8.0
       typescript:
-        specifier: ~6.0.3
-        version: 6.0.3
+        specifier: ~7.0.2
+        version: 7.0.2
       vite:
         specifier: ^7.1.9
         version: 7.3.6(@types/node@24.13.3)(@types/picomatch@4.0.3)(jiti@2.6.1)(yaml@2.9.0)
@@ -2935,12 +2935,12 @@ snapshots:
   '@biomejs/cli-win32-x64@2.5.6':
     optional: true
 
-  '@commitlint/cli@21.2.1(@types/node@24.13.3)(conventional-commits-parser@7.1.1)(typescript@6.0.3)':
+  '@commitlint/cli@21.2.1(@types/node@24.13.3)(conventional-commits-parser@7.1.1)(typescript@7.0.2)':
     dependencies:
       '@commitlint/config-conventional': 21.2.0
       '@commitlint/format': 21.2.0
       '@commitlint/lint': 21.2.0
-      '@commitlint/load': 21.2.0(@types/node@24.13.3)(typescript@6.0.3)
+      '@commitlint/load': 21.2.0(@types/node@24.13.3)(typescript@7.0.2)
       '@commitlint/read': 21.2.1(conventional-commits-parser@7.1.1)
       '@commitlint/types': 21.2.0
       '@types/yargs': 17.0.35
@@ -2987,14 +2987,14 @@ snapshots:
       '@commitlint/rules': 21.2.0
       '@commitlint/types': 21.2.0
 
-  '@commitlint/load@21.2.0(@types/node@24.13.3)(typescript@6.0.3)':
+  '@commitlint/load@21.2.0(@types/node@24.13.3)(typescript@7.0.2)':
     dependencies:
       '@commitlint/config-validator': 21.2.0
       '@commitlint/execute-rule': 21.0.1
       '@commitlint/resolve-extends': 21.2.0
       '@commitlint/types': 21.2.0
-      cosmiconfig: 9.0.2(typescript@6.0.3)
-      cosmiconfig-typescript-loader: 6.3.0(@types/node@24.13.3)(cosmiconfig@9.0.2(typescript@6.0.3))(typescript@6.0.3)
+      cosmiconfig: 9.0.2(typescript@7.0.2)
+      cosmiconfig-typescript-loader: 6.3.0(@types/node@24.13.3)(cosmiconfig@9.0.2(typescript@7.0.2))(typescript@7.0.2)
       es-toolkit: 1.50.0
       is-plain-obj: 4.1.0
       picocolors: 1.1.1
@@ -4101,14 +4101,14 @@ snapshots:
       graceful-fs: 4.2.11
       p-event: 6.0.1
 
-  cosmiconfig-typescript-loader@6.3.0(@types/node@24.13.3)(cosmiconfig@9.0.2(typescript@6.0.3))(typescript@6.0.3):
+  cosmiconfig-typescript-loader@6.3.0(@types/node@24.13.3)(cosmiconfig@9.0.2(typescript@7.0.2))(typescript@7.0.2):
     dependencies:
       '@types/node': 24.13.3
-      cosmiconfig: 9.0.2(typescript@6.0.3)
+      cosmiconfig: 9.0.2(typescript@7.0.2)
       jiti: 2.6.1
-      typescript: 6.0.3
+      typescript: 7.0.2
 
-  cosmiconfig@9.0.2(typescript@6.0.3):
+  cosmiconfig@9.0.2(typescript@7.0.2):
     dependencies:
       '@types/js-yaml': 4.0.9
       '@types/parse-json': 4.0.2
@@ -4117,7 +4117,7 @@ snapshots:
       js-yaml: 4.3.0
       parse-json: 5.2.0
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: 7.0.2
 
   cpy-cli@7.0.0:
     dependencies:


### PR DESCRIPTION
## Summary

- Bump the `typescript` devDependency from `~6.0.3` to `~7.0.2` (the oldest stable TypeScript 7 release) in the root `package.json` and in `packages/example-cli`, `packages/example-lib`, and `packages/sea-builder`, aligning every workspace consumer with the `>=7.0.0` peer floor `typescript-config` already declares since PR #115.
- Leave `packages/vite-lib-config/package.json`'s `typescript` at `~6.0.3` — out of scope here because its `typedoc@^0.28.13` devDependency has a hard-capped, non-optional `typescript` peer range with no `7.x` support yet (tracked separately in #120).
- Regenerate `pnpm-lock.yaml` accordingly (only the `typescript` entry moves `6.0.3` → `7.0.2`; no other package resolves differently).

Closes #119

## Verification

Ran locally on this branch, all green:

- `pnpm install --frozen-lockfile` — clean install against the regenerated lockfile.
- `pnpm run lint:fix` then `pnpm run lint` — clean, no fixes needed.
- `pnpm run build` — all packages build, including `vite-lib-config` still on `~6.0.3`.
- `pnpm run test` — `test:ts` (workspace-wide `tsc -p tsconfig.test.json --noEmit`, excluding `typescript-config`) passes with no new errors under TypeScript 7; `test:vitest` passes 22/22 files, 80/80 tests.

## Background

`npm view typescript versions` confirms no stable `7.0.0`/`7.0.1` release exists (only a `7.0.1-rc` prerelease and `7.1.0-dev.*` prereleases beyond `7.0.2`), so `~7.0.2` is genuinely the oldest stable TypeScript 7 release — matching this repository's version-floor convention (oldest-that-works, not npm `latest`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the TypeScript tooling version across the project and example packages.
  * No user-facing functionality or public APIs were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->