### PR TITLE
chore(idd): trust empty branch-protection reads on this ruleset-only repo

### DIFF
--- a/.github/idd/config.json
+++ b/.github/idd/config.json
@@ -36,7 +36,8 @@
     "chatgpt-codex-connector[bot]"
   ],
   "ciGate": {
-    "trustSourcePinnedRequiredChecks": true
+    "trustSourcePinnedRequiredChecks": true,
+    "trustEmptyProtectionReads": true
   },
   "autopilotSuitability": {
     "floor": 3

--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -137,6 +137,25 @@ a "forged check" actor is already a fully-trusted actor by this
 repository's own merge policy. Revisit if this repository ever accepts
 external contributions from untrusted authors.
 
+**`ciGate.trustEmptyProtectionReads`**: `true`, enabled (2026-08-12).
+This repository enforces its merge gate through a Ruleset only
+(`main`, id `20674407`) and has no classic branch-protection record —
+`gh api repos/kurone-kito/builder-config/branches/main/protection`
+genuinely returns `404 Branch not protected`, not a masked `403`.
+Confirmed before enabling: the automation token carries the `repo`
+scope and resolves as an `admin` collaborator
+(`gh api repos/kurone-kito/builder-config/collaborators/kurone-kito/permission`),
+and the same token's Ruleset reads already succeed and correctly
+resolve `idd-advisory-convergence` as the sole required check — so the
+`404` cannot be this token lacking read access; it is a genuine "not
+configured" result. Without this flag, the required-check-discovery
+fail-closed default (`idd-ci.instructions.md`'s Required-check
+discovery step 4) treats every classic-protection `404` as unreadable
+and holds at F2/F3 regardless of Ruleset state, which blocked the
+merge of issue `#124` before this flag was set. Revisit if this
+repository ever adds classic branch protection alongside its Ruleset,
+or if the automation token's scope is ever narrowed below `repo`.
+
 ## Credential Scope
 
 **Worker credentials**: repository write access for issue/PR/branch


### PR DESCRIPTION
## Summary

- Sets `ciGate.trustEmptyProtectionReads: true` in `.github/idd/config.json`, and records the decision in `docs/idd-policy.md`'s External CI-Check Trust section.

## Why

This repository enforces its merge gate through a repository Ruleset only (`main`, id `20674407`) — it has no classic branch-protection record, so `GET branches/main/protection` genuinely returns `404 Branch not protected`. `idd-ci.instructions.md`'s Required-check discovery step 4 fails closed by default on any `404` from that endpoint (since GitHub's own docs never list `403` as a possible response there, a `404` is structurally ambiguous between "nothing configured" and "the token can't read it"), holding merge at F2/F3 regardless of Ruleset state. This blocked the merge of issue `#124` during today's IDD batch.

Verified before enabling, per the flag's own documented requirement ("only when the repository operator has verified the automation token is known to carry full read access to these specific endpoints"):

- The automation token carries the `repo` OAuth scope (`gh auth status`).
- It resolves as an `admin` collaborator on this repository (`gh api repos/kurone-kito/builder-config/collaborators/kurone-kito/permission`).
- The same token's Ruleset reads already succeed and correctly resolve `idd-advisory-convergence` as the sole required check (`gh api repos/kurone-kito/builder-config/rulesets/20674407`).

Since a lack of read access would also affect the Ruleset reads (which already work correctly), the `404` on the classic-protection endpoint reflects a genuine "not configured" state, not a permission gap — enabling this flag is safe for this repository as currently configured.

## Verification

- `pnpm run lint:fix` / `pnpm run lint` — clean.
- `pnpm run build` — all 5 buildable workspace packages, exit 0.
- `pnpm run test` — 22/22 test files, 81/81 tests passed.

This is a repository policy/config change authorized directly by the maintainer (kurone-kito) in the driving session, not IDD-claimed work tied to a tracked issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the IDD policy to clarify CI protection settings, token permissions, and Ruleset validation.
  * Documented when the empty protection-read trust setting should be revisited.

* **Chores**
  * Enabled support for trusted empty protection-read results in CI gating.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->