### PR TITLE
fix(deps): move sea-builder's @types/semver to dependencies

### DIFF
--- a/packages/sea-builder/package.json
+++ b/packages/sea-builder/package.json
@@ -38,6 +38,7 @@
     "test": "vitest run --coverage"
   },
   "dependencies": {
+    "@types/semver": "^7.8.0",
     "all-node-versions": "^13.0.1",
     "execa": "^10.0.0",
     "listr2": "^9.0.4",
@@ -48,7 +49,6 @@
     "@kurone-kito/typescript-config": "workspace:^",
     "@kurone-kito/vite-lib-config": "workspace:^",
     "@types/node": "^24.6.2",
-    "@types/semver": "^7.8.0",
     "@vitest/coverage-v8": "^4.1.0",
     "cpy-cli": "^7.0.0",
     "rimraf": "^6.0.1",


### PR DESCRIPTION
## Summary

`@pnpm/plugin-types-fixer`'s `readPackage` hook deterministically
promotes a `devDependencies`-declared `@types/*` package into
`dependencies` in `pnpm-lock.yaml` whenever the package's own
untyped counterpart (here, `semver`) is already listed under
`dependencies`. This runs on every install and is not a stale
lockfile artifact — a clean-room reinstall reproduces it
byte-identical.

`packages/sea-builder`'s `package.json` had `@types/semver` under
`devDependencies`, leaving it inconsistent with what the lockfile has
always computed. This aligns `package.json` with the lockfile instead
of the reverse.

- `packages/sea-builder` is `bin`-only (no `main`/`types`/`exports`
  field), so it doesn't need the plugin's "downstream TypeScript
  consumer" promotion in principle — but reversing the plugin's
  behavior (or scoping it out for bin-only packages) is a separate,
  larger decision, tracked as a documented but declined option on the
  issue rather than implemented here.
- `packages/vite-lib-config` has the identical `lodash-es` /
  `@types/lodash-es` pattern, but that package does publish types, so
  the same promotion is plausibly intentional there — out of scope
  for this change; flagged on the issue for a separate check.

Closes #131

## Test plan

- [x] `pnpm install` — lockfile already matched (0 diff), confirming
      the categorization is plugin-computed rather than
      package.json-driven
- [x] `pnpm run lint:fix` && `pnpm run lint`
- [x] `pnpm run build`
- [x] `pnpm run test` (81 tests passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pp83wfp8YJ8HuEegArMJvi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package dependency configuration to ensure semantic versioning type support is available at runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->