### PR TITLE
test: disposable PR for #51 required-check refresh-path verification

### DIFF
--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -561,3 +561,5 @@ hook file invokes them changed.
 
   See the matching step in the release checklist in
   [`.github/copilot-instructions.md`](../.github/copilot-instructions.md#release-checklist).
+
+<!-- idd-51-waiver-refresh-throwaway-test: disposable marker, PR will be closed without merge -->


### PR DESCRIPTION
Disposable PR to exercise #51's acceptance criterion 3: confirm that
re-running the existing \`idd-advisory-convergence\` job for the
current HEAD (not \`workflow_dispatch\`) is what refreshes the
required-check rollup.

**This PR will be closed without merge once the check is verified.**

Refs #51