### PR TITLE
chore(deps): bump the idd-skill helper pin past v0.6.0 for #1921/#1924 fixes

### DIFF
--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -175,10 +175,11 @@ the npm registry**; its default dependency spec is a moving
 to a reviewed commit archive for reproducibility:
 
 ```text
-https://codeload.github.com/kurone-kito/idd-skill/tar.gz/0a9c90dc277e05e0d7d96f1b09d79ff668860cc6
+https://codeload.github.com/kurone-kito/idd-skill/tar.gz/83d5f2ae1e6502d95c3d675f807574c42742ef4d
 ```
 
-(idd-skill commit `0a9c90d`, tag `v0.6.0`, `@kurone-kito/idd-skill@0.6.0`.)
+(idd-skill commit `83d5f2a`, an unreleased `main` snapshot past
+`v0.6.0` — no newer tag exists yet; `@kurone-kito/idd-skill@0.6.0`.)
 Bump this pin deliberately (re-run
 `idd-helper-bundle-manifest --profile package-manager --package-spec <new-pin>`
 from a newer idd-skill clone) rather than letting it drift to `main`.

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "@kurone-kito/commitlint-config": "^0.22.0",
     "@kurone-kito/cspell-config": "^0.22.0",
     "@kurone-kito/example-cli": "workspace:^",
-    "@kurone-kito/idd-skill": "https://codeload.github.com/kurone-kito/idd-skill/tar.gz/0a9c90dc277e05e0d7d96f1b09d79ff668860cc6",
+    "@kurone-kito/idd-skill": "https://codeload.github.com/kurone-kito/idd-skill/tar.gz/83d5f2ae1e6502d95c3d675f807574c42742ef4d",
     "@kurone-kito/lint-staged-config": "^0.22.0",
     "@kurone-kito/markdownlint-config": "^0.22.0",
     "@types/semver": "^7.8.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,8 +62,8 @@ importers:
         specifier: workspace:^
         version: link:packages/example-cli
       '@kurone-kito/idd-skill':
-        specifier: https://codeload.github.com/kurone-kito/idd-skill/tar.gz/0a9c90dc277e05e0d7d96f1b09d79ff668860cc6
-        version: https://codeload.github.com/kurone-kito/idd-skill/tar.gz/0a9c90dc277e05e0d7d96f1b09d79ff668860cc6
+        specifier: https://codeload.github.com/kurone-kito/idd-skill/tar.gz/83d5f2ae1e6502d95c3d675f807574c42742ef4d
+        version: https://codeload.github.com/kurone-kito/idd-skill/tar.gz/83d5f2ae1e6502d95c3d675f807574c42742ef4d
       '@kurone-kito/lint-staged-config':
         specifier: ^0.22.0
         version: 0.22.0(cspell@10.0.1)(lint-staged@17.3.0)
@@ -731,8 +731,8 @@ packages:
       cspell:
         optional: true
 
-  '@kurone-kito/idd-skill@https://codeload.github.com/kurone-kito/idd-skill/tar.gz/0a9c90dc277e05e0d7d96f1b09d79ff668860cc6':
-    resolution: {tarball: https://codeload.github.com/kurone-kito/idd-skill/tar.gz/0a9c90dc277e05e0d7d96f1b09d79ff668860cc6}
+  '@kurone-kito/idd-skill@https://codeload.github.com/kurone-kito/idd-skill/tar.gz/83d5f2ae1e6502d95c3d675f807574c42742ef4d':
+    resolution: {gitHosted: true, integrity: sha512-gBKl9x5N2bYag0SPG0o9UEYtvVXsXnEwJJfgn7mr+OaJJluhACrwEFKK/+3za8NJl/WNSZG54NQhhlc7lYyWZQ==, tarball: https://codeload.github.com/kurone-kito/idd-skill/tar.gz/83d5f2ae1e6502d95c3d675f807574c42742ef4d}
     version: 0.6.0
     engines: {node: ^22.22.2 || >=24.2.0}
     hasBin: true
@@ -3023,7 +3023,7 @@ snapshots:
     optionalDependencies:
       cspell: 10.0.1
 
-  '@kurone-kito/idd-skill@https://codeload.github.com/kurone-kito/idd-skill/tar.gz/0a9c90dc277e05e0d7d96f1b09d79ff668860cc6': {}
+  '@kurone-kito/idd-skill@https://codeload.github.com/kurone-kito/idd-skill/tar.gz/83d5f2ae1e6502d95c3d675f807574c42742ef4d': {}
 
   '@kurone-kito/lint-staged-config@0.22.0(cspell@10.0.1)(lint-staged@17.3.0)':
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,5 @@
 allowBuilds:
-  '@kurone-kito/idd-skill@https://codeload.github.com/kurone-kito/idd-skill/tar.gz/0a9c90dc277e05e0d7d96f1b09d79ff668860cc6': true
+  '@kurone-kito/idd-skill@https://codeload.github.com/kurone-kito/idd-skill/tar.gz/83d5f2ae1e6502d95c3d675f807574c42742ef4d': true
   esbuild: true
 configDependencies:
   '@pnpm/plugin-types-fixer': 0.1.0+sha512-bLww63gRHi7siYTqFJb5qNdcXadU0jv20Et6z5AryMZ7FlLolbEJOrXLpg8+amQZNHHNW1dfFUBGVw/9ezQbFg==


### PR DESCRIPTION
## Summary

- Bumps the pinned `@kurone-kito/idd-skill` devDependency from commit
  `0a9c90d` (tag `v0.6.0`, 2026-08-06) to current `main`
  (`83d5f2a`), which includes two upstream fixes this repo's own IDD
  loop execution hit in practice: kurone-kito/idd-skill#1921 (`pnpm
  run idd:<name> -- --flag` crashing on the forwarded `--`) and #1924
  (`idd-onboard --verify` flagging reference docs' documented
  placeholder syntax as unresolved residue). No newer tag has been
  cut yet, so this pins to a `main` snapshot rather than a tag.
- Also updates `pnpm-workspace.yaml`'s `allowBuilds` entry to match
  the new package spec — pnpm keys build approval by the exact spec
  string, so a pin bump alone left the old entry orphaned and the
  install failing closed (`ERR_PNPM_GIT_DEP_PREPARE_NOT_ALLOWED`);
  found this empirically while implementing, not called out in the
  original issue.
- Updates `docs/idd-policy.md`'s Helper Runtime Profile section to
  record the new commit.

Closes #135

## Test plan

- [x] `pnpm install --frozen-lockfile` succeeds; lockfile diff is
      scoped to the pin change only.
- [x] `pnpm run idd:doctor` — same 3 pre-existing warnings, no new
      errors.
- [x] Spot-check #1921: `pnpm run idd:doctor -- --help` now prints
      help text instead of crashing with a raw stack trace.
- [x] Spot-check #1924: `idd-onboard --verify` against a fresh
      upstream clone no longer flags `docs/onboarding/placeholders.md`,
      `docs/customization.md`, or `docs/onboarding/policy-decisions.md`
      (a 4th file, `docs/onboarding/agent-entry-and-verification.md`,
      still shows the same class of residue — out of #1924's own
      declared scope, filed upstream separately, not part of this
      issue's acceptance criteria).
- [x] `pnpm run lint:fix` && `pnpm run lint`
- [x] `pnpm run build`
- [x] `pnpm run test` (81 tests passed)
- [x] Independent critique pass (subagent review of the diff):
      clean, old SHA fully purged repo-wide, `allowBuilds` key
      verified byte-for-byte, no unrelated changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pp83wfp8YJ8HuEegArMJvi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project’s supporting tooling to a newer revision.
  * Refreshed related setup and policy references to keep development workflows aligned.
  * No changes to user-facing features or publicly available functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->