### PR TITLE
fix(ci): refine release-drafter categorization and adopt lints-config improvements

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -6,19 +6,23 @@ tag-template: v$NEXT_PATCH_VERSION
 # mark IDD workflow state, not a PR's actual change type.
 categories:
   - title: 🚀 Features
+    exclusive: true
     when:
       labels:
         - enhancement
   - title: 🐛 Bug Fixes
+    exclusive: true
     when:
       labels:
         - bug
   - title: 📝 Documentation
+    exclusive: true
     when:
       labels:
         - documentation
   - title: 🧰 Maintenance
     collapse-after: 5
+    exclusive: true
     when:
       labels:
         - chore

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -22,6 +22,7 @@ categories:
     when:
       labels:
         - chore
+        - dependencies
 autolabeler:
   - label: enhancement
     title:

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,30 +1,42 @@
-name-template: v$RESOLVED_VERSION 🌈
-tag-template: v$RESOLVED_VERSION
+name-template: v$NEXT_PATCH_VERSION 🌈
+tag-template: v$NEXT_PATCH_VERSION
+# Do not use IDD's reserved labels (`roadmap`, `status:blocked-by-human`,
+# `status:needs-decision`, `status:authoring`; see docs/idd-policy.md
+# § IDD Labels) as a release-drafter category label below — those labels
+# mark IDD workflow state, not a PR's actual change type.
 categories:
   - title: 🚀 Features
-    labels:
-      - feature
-      - enhancement
+    when:
+      labels:
+        - enhancement
   - title: 🐛 Bug Fixes
-    labels:
-      - fix
-      - bugfix
-      - bug
+    when:
+      labels:
+        - bug
+  - title: 📝 Documentation
+    when:
+      labels:
+        - documentation
   - title: 🧰 Maintenance
-    label: chore
+    collapse-after: 5
+    when:
+      labels:
+        - chore
+autolabeler:
+  - label: enhancement
+    title:
+      - '/^feat(\(.+\))?!?:/'
+  - label: bug
+    title:
+      - '/^fix(\(.+\))?!?:/'
+  - label: documentation
+    title:
+      - '/^docs(\(.+\))?!?:/'
+  - label: chore
+    title:
+      - '/^(chore|ci|build|refactor|perf|test|revert|style)(\(.+\))?!?:/'
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
 change-title-escapes: '\<*_&'
-version-resolver:
-  major:
-    labels:
-      - major
-  minor:
-    labels:
-      - minor
-  patch:
-    labels:
-      - patch
-  default: patch
 template: |
   ## Changes
 

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -9,7 +9,6 @@ on:
       - opened
       - reopened
       - synchronize
-      - edited
     branches:
       - main
 permissions:

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -23,7 +23,9 @@ jobs:
       - uses: release-drafter/release-drafter@34d80673e067bdc0c24568d3af899c216adcfaa9 # v7.7.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - if: github.event_name == 'pull_request'
+      - if: >-
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository
         uses: release-drafter/release-drafter/autolabeler@34d80673e067bdc0c24568d3af899c216adcfaa9 # v7.7.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -9,6 +9,7 @@ on:
       - opened
       - reopened
       - synchronize
+      - edited
     branches:
       - main
 permissions:
@@ -27,5 +28,6 @@ jobs:
           github.event_name == 'pull_request' &&
           github.event.pull_request.head.repo.full_name == github.repository
         uses: release-drafter/release-drafter/autolabeler@34d80673e067bdc0c24568d3af899c216adcfaa9 # v7.7.0
+        continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -23,3 +23,7 @@ jobs:
       - uses: release-drafter/release-drafter@34d80673e067bdc0c24568d3af899c216adcfaa9 # v7.7.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - if: github.event_name == 'pull_request'
+        uses: release-drafter/release-drafter/autolabeler@34d80673e067bdc0c24568d3af899c216adcfaa9 # v7.7.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -543,8 +543,9 @@ hook file invokes them changed.
   1. For every package the release actually changed, add an entry
      under its `## [Unreleased]` heading for each user-facing change
      since the last release (source: the merged PRs in range, using
-     the same 🚀 Features / 🐛 Bug Fixes / 🧰 Maintenance categorization
-     `.github/release-drafter.yml` already applies).
+     the same 🚀 Features / 🐛 Bug Fixes / 📝 Documentation /
+     🧰 Maintenance categorization `.github/release-drafter.yml` already
+     applies).
   2. For every touched package that now has `[Unreleased]` entries,
      insert a new `## [<version>] - <YYYY-MM-DD>` heading directly
      below `## [Unreleased]` and move those entries under it, then

--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -544,8 +544,8 @@ hook file invokes them changed.
      under its `## [Unreleased]` heading for each user-facing change
      since the last release (source: the merged PRs in range, using
      the same 🚀 Features / 🐛 Bug Fixes / 📝 Documentation /
-     🧰 Maintenance categorization `.github/release-drafter.yml` already
-     applies).
+     🧰 Maintenance categorization that `.github/release-drafter.yml`
+     already applies).
   2. For every touched package that now has `[Unreleased]` entries,
      insert a new `## [<version>] - <YYYY-MM-DD>` heading directly
      below `## [Unreleased]` and move those entries under it, then


### PR DESCRIPTION
## Summary

`.github/release-drafter.yml`'s categorization never actually worked:
every category matched on a PR label, but nothing in this repo ever
applied one. `release-drafter/release-drafter@v7` only drafts the
release notes; the label-applying logic lives in a separate compiled
action, `release-drafter/release-drafter/autolabeler@v7`, which no
workflow in this repo invoked. Maintainer-authorized in #140's comment
thread (Option A) to add that missing step within this issue's scope.

- `.github/workflows/push-main.yml`: one additive step in the existing
  `update_release_draft` job, SHA-pinned to the same v7.7.0 commit
  already used by the drafter step, guarded by
  `if: github.event_name == 'pull_request'` (the autolabeler action
  throws on any other event, and this job also triggers on `push`). No
  new permissions or triggers needed.
- `.github/release-drafter.yml`:
  - Add an `autolabeler` block mapping Conventional Commit PR-title
    prefixes to labels: `feat` → `enhancement`, `fix` → `bug`, `docs`
    → `documentation`, and `chore`/`ci`/`build`/`refactor`/`perf`/
    `test`/`revert`/`style` → a new `chore` label (covers the full
    `@commitlint/config-conventional` default type-enum).
  - Rewrite `categories` using the modern `when.labels` condition form
    (the deprecated top-level `label`/`labels` shorthand still works
    but emits a migration warning every run), keeping only labels
    that exist or now exist: `enhancement`, `bug`, `documentation`,
    `chore`. Dropped the dead `feature`/`fix`/`bugfix` entries nothing
    ever applied.
  - Add a "📝 Documentation" category and `collapse-after: 5` on
    Maintenance.
  - Add a comment warning against using this repo's IDD-reserved
    labels (`roadmap`, `status:blocked-by-human`,
    `status:needs-decision`, `status:authoring`) as a category label.
  - Drop `version-resolver` (major/minor/patch labels never existed
    here, so it always fell through to `default: patch`) in favor of
    `$NEXT_PATCH_VERSION` directly — a deliberate choice, not a
    silently dropped capability, since this repo has no plan to
    introduce those three labels.
- `docs/idd-policy.md`: added the new Documentation category to the
  CHANGELOG Policy section's category list so it stays accurate.
- Created the `chore` label (already referenced by the *current*
  config's Maintenance category but missing from the repo's label
  set).

Closes #140

## Verification

- `pnpm run lint`, `pnpm run build`, `pnpm run test` all pass locally.
- YAML validity independently double-checked with `yaml.safe_load`
  (this repo's `lint` pipeline is biome/cspell/markdownlint and does
  not itself parse YAML).
- Both changed schemas (drafter's own `schema.json` and the separate
  `autolabeler/schema.json`) were checked directly against the pinned
  commit `34d80673e067bdc0c24568d3af899c216adcfaa9`; neither is
  `additionalProperties: false` at the root, so the drafter step
  safely ignores the new `autolabeler:` key and vice versa.
- **This PR's own `pull_request`-triggered run exercises the
  autolabeler step live**: because the action reads the workflow and
  config content from the PR's own merge ref, this PR (titled
  `fix(ci): ...`) should get auto-labeled `bug` the moment CI runs —
  will confirm and report the actual observed label.
- **Not verifiable pre-merge**: the draft release's categorized
  sections. That requires a `push`-triggered `update_release_draft`
  run against `main` after this PR (and at least one labeled PR)
  merges. **Please spot-check the live draft release
  (`gh api repos/kurone-kito/builder-config/releases --jq '.[] |
  select(.draft==true) | .body'`) after the next merge** to confirm
  genuinely categorized sections appear, per the issue's own
  acceptance criteria.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release notes now use the next patch version for release names and tags.
  * Pull requests are automatically categorized by Conventional Commit-style titles.
  * Added distinct categories for enhancements, bug fixes, documentation, and maintenance.

* **Documentation**
  * Updated the changelog policy to include a Documentation category.

* **Chores**
  * Release automation now responds to edited pull requests and safely handles labeling failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->