### PR TITLE
docs(idd): note the pnpm -- passthrough footgun for four helper scripts

### DIFF
--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -599,6 +599,23 @@ retained. `instructions-only` uses neither. When an instruction shows a
 `node scripts/...` command, resolve it to your profile's authoritative surface
 rather than maintaining both.
 
+**pnpm `--`-passthrough footgun.** Under `package-manager`, `pnpm run
+idd:<name> -- <flag>...` forwards the literal `--` separator to the
+invoked script instead of stripping it (npm strips it; pnpm does not).
+`idd-skill`'s shared `cli-args.mts` parser strips one leading bare `--`,
+so most `idd:<name>` scripts tolerate either form — but four scripts
+route around that shared parser and reproduce the footgun:
+`idd:post-idd-marker` and `idd:emit-marker` fail with `missing value for
+argument: --`; `idd:discover-orphan-filter` and
+`idd:discover-roadmap-graph` fail with `unknown argument: --`. Invoke
+these four **without** a leading `--` separator —
+`pnpm run idd:post-idd-marker --type claim ...`, not
+`pnpm run idd:post-idd-marker -- --type claim ...` — every other
+`idd:<name>` script in this repository's `package.json` tolerates either
+form. This is a known upstream (`idd-skill`) gap, not a local
+misconfiguration; revisit this note whenever the `@kurone-kito/idd-skill`
+pin changes, since a future bump may narrow or remove the affected list.
+
 **Authoring rule for instructions/docs.** A mandatory helper step (one
 with no skip/fallback wording) must always name an `instructions-only`
 fallback, since that profile has no helper runtime at all. Every helper

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -599,22 +599,23 @@ retained. `instructions-only` uses neither. When an instruction shows a
 `node scripts/...` command, resolve it to your profile's authoritative surface
 rather than maintaining both.
 
-**pnpm `--`-passthrough footgun.** Under `package-manager`, `pnpm run
-idd:<name> -- <flag>...` forwards the literal `--` separator to the
-invoked script instead of stripping it (npm strips it; pnpm does not).
-`idd-skill`'s shared `cli-args.mts` parser strips one leading bare `--`,
-so most `idd:<name>` scripts tolerate either form — but four scripts
-route around that shared parser and reproduce the footgun:
-`idd:post-idd-marker` and `idd:emit-marker` fail with `missing value for
-argument: --`; `idd:discover-orphan-filter` and
+**pnpm `--`-passthrough footgun.** Under `package-manager`,
+`pnpm run idd:<name> -- <flag>...` forwards the literal `--` separator
+to the invoked script instead of stripping it (npm strips it; pnpm does
+not). `idd-skill`'s shared `cli-args.mts` parser strips one leading bare
+`--`, so most `idd:<name>` scripts tolerate either form — but four
+scripts route around that shared parser and reproduce the footgun:
+`idd:post-idd-marker` and `idd:emit-marker` fail with
+`missing value for argument: --`; `idd:discover-orphan-filter` and
 `idd:discover-roadmap-graph` fail with `unknown argument: --`. Invoke
 these four **without** a leading `--` separator —
 `pnpm run idd:post-idd-marker --type claim ...`, not
 `pnpm run idd:post-idd-marker -- --type claim ...` — every other
-`idd:<name>` script in this repository's `package.json` tolerates either
-form. This is a known upstream (`idd-skill`) gap, not a local
-misconfiguration; revisit this note whenever the `@kurone-kito/idd-skill`
-pin changes, since a future bump may narrow or remove the affected list.
+`idd:<name>` script in this repository's `package.json` tolerates
+either form. This is a known upstream (`idd-skill`) gap, not a local
+misconfiguration; revisit this note whenever the
+`@kurone-kito/idd-skill` pin changes, since a future bump may narrow or
+remove the affected list.
 
 **Authoring rule for instructions/docs.** A mandatory helper step (one
 with no skip/fallback wording) must always name an `instructions-only`


### PR DESCRIPTION
## Summary

Adds a short note to `docs/idd-helper-scripts.md`, next to the existing
"Authoritative invocation surface per profile" section, documenting a
pnpm-specific `--`-forwarding footgun. pnpm forwards a literal `--`
separator to invoked `package.json` scripts instead of stripping it
(npm strips it). `idd-skill`'s shared `cli-args.mts` parser already
strips one leading bare `--`, but four `idd:<name>` scripts route
around that shared parser and reproduce the footgun: `idd:post-idd-marker`
and `idd:emit-marker` fail with `missing value for argument: --`;
`idd:discover-orphan-filter` and `idd:discover-roadmap-graph` fail with
`unknown argument: --`. The note states the workaround (drop the
leading `--`) with a concrete before/after example.

Closes #145

## Background

Two of the six `idd-skill` scripts excluded from the shared parser were
checked and found *not* to need a workaround note, for different
reasons, so this PR deliberately does not list them: `idd:merge-execute`
absorbs the stray `--` into a `passthrough` array that a downstream,
already-fixed parser strips, so it never reproduces the bug in
practice; `idd:onboard` has no corresponding `package.json` script in
this repository at all.

This is a known upstream (`idd-skill`) gap, not a local
misconfiguration; the note flags itself for review whenever the
`@kurone-kito/idd-skill` pin changes, since a future bump may narrow or
remove the affected list.

Documentation-only change — no code, workflow, or config file changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented a pnpm argument-forwarding compatibility issue affecting four `idd:*` commands.
  * Added corrected command examples that omit the argument separator.
  * Noted that the affected command list should be reviewed after dependency updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->