### PR TITLE
fix(root): make the prepare script's hook wiring Windows-native

### DIFF
--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -503,11 +503,11 @@ rather than accepting the permanent false-positive warning:
   confirmed empirically (`if` fails with `command not found: if` under
   the emulator, even though it works under a real POSIX shell).
 
-  The script intentionally does **not** `chmod +x` the hook files: `git
-  ls-files -s .githooks/` already reports mode `100755` for
-  `pre-commit`, `pre-push`, and `commit-msg`, and a normal `git
-  checkout` restores that index-recorded mode on its own, so a dynamic
-  `chmod` at install time never changed anything. Any *future*
+  The script intentionally does **not** `chmod +x` the hook files:
+  `git ls-files -s .githooks/` already reports mode `100755` for
+  `pre-commit`, `pre-push`, and `commit-msg`, and a normal
+  `git checkout` restores that index-recorded mode on its own, so a
+  dynamic `chmod` at install time never changed anything. Any *future*
   `.githooks/*` file must be committed with its executable bit already
   set — for example `git update-index --chmod=+x <path>` before
   committing, or by copying an existing hook file's mode — since

--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -484,25 +484,34 @@ rather than accepting the permanent false-positive warning:
   `pnpm install`.
 
   ```sh
-  git rev-parse --git-dir > /dev/null 2>&1 || exit 0; git config core.hooksPath .githooks && chmod +x .githooks/pre-commit .githooks/pre-push .githooks/commit-msg
+  git rev-parse --git-dir > /dev/null 2>&1 || exit 0; git config core.hooksPath .githooks
   ```
 
   The `git rev-parse --git-dir` guard keeps this a no-op (exit 0) when
   `pnpm install` runs outside a Git worktree — a "Download ZIP"
   checkout or a registry-tarball install has no `.git` to configure,
   and hooks are meaningless there anyway. Inside a Git worktree, a
-  genuine `git config`/`chmod` failure still propagates (fails the
-  install) rather than being silently swallowed — an earlier
-  `... || true` shape suppressed that class of failure too, which
-  would have left hooks silently unwired (worktree guard, lint-staged,
-  commitlint all inert) with no signal to the developer. This uses
-  `exit 0` plus `;`/`&&`/`||` chaining rather than `if`/`then`/`fi`:
-  this repository's `pnpm-workspace.yaml` sets `shellEmulator: true`
-  for cross-platform lifecycle scripts (Windows CI included), and that
-  emulator supports simple command chaining but not full POSIX
-  control-flow keywords — confirmed empirically (`if` fails with
-  `command not found: if` under the emulator, even though it works
-  under a real POSIX shell).
+  genuine `git config` failure still propagates (fails the install)
+  rather than being silently swallowed — an earlier `... || true`
+  shape suppressed that class of failure too, which would have left
+  hooks silently unwired (worktree guard, lint-staged, commitlint all
+  inert) with no signal to the developer. This uses `exit 0` plus
+  `;`/`||` chaining rather than `if`/`then`/`fi`: this repository's
+  `pnpm-workspace.yaml` sets `shellEmulator: true` for cross-platform
+  lifecycle scripts (Windows CI included), and that emulator supports
+  simple command chaining but not full POSIX control-flow keywords —
+  confirmed empirically (`if` fails with `command not found: if` under
+  the emulator, even though it works under a real POSIX shell).
+
+  The script intentionally does **not** `chmod +x` the hook files: `git
+  ls-files -s .githooks/` already reports mode `100755` for
+  `pre-commit`, `pre-push`, and `commit-msg`, and a normal `git
+  checkout` restores that index-recorded mode on its own, so a dynamic
+  `chmod` at install time never changed anything. Any *future*
+  `.githooks/*` file must be committed with its executable bit already
+  set — for example `git update-index --chmod=+x <path>` before
+  committing, or by copying an existing hook file's mode — since
+  `prepare` no longer fixes this up at install time.
 
 `lint-staged`'s and `commitlint`'s own configuration
 (`.lintstagedrc.mjs`, `.commitlintrc.yml`) are unchanged; only which

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "postlint:fix": "pnpm run lint:cspell:check",
     "pnpm:devPreinstall": "pnpm --if-present --workspace-concurrency=0 -r run devPreinstall",
     "predev": "pnpm run build",
-    "prepare": "git rev-parse --git-dir > /dev/null 2>&1 || exit 0; git config core.hooksPath .githooks && chmod +x .githooks/pre-commit .githooks/pre-push .githooks/commit-msg",
+    "prepare": "git rev-parse --git-dir > /dev/null 2>&1 || exit 0; git config core.hooksPath .githooks",
     "pretest": "pnpm run build",
     "publish": "pnpm -r publish --no-git-checks",
     "publish:next": "pnpm -r publish --tag next --no-git-checks",


### PR DESCRIPTION
## Summary

The root `package.json`'s `prepare` script's `chmod +x .githooks/...`
clause is dead weight and a Windows footgun:

- `.githooks/pre-commit`, `.githooks/pre-push`, and `.githooks/commit-msg`
  are already committed with mode `100755` in the git index, and a
  normal `git checkout` restores that mode on its own — the dynamic
  `chmod` has never changed anything in this repository's history.
- `pnpm-workspace.yaml`'s `shellEmulator: true` routes lifecycle
  scripts through `@yarnpkg/shell`, whose builtins have no `chmod` —
  it falls through to external-command resolution against the OS
  `PATH`. A native Windows machine without Git's `usr/bin` on `PATH`
  has no `chmod` binary at all, so `pnpm install` could fail outright
  on that step.

This PR drops the clause, leaving:

```sh
git rev-parse --git-dir > /dev/null 2>&1 || exit 0; git config core.hooksPath .githooks
```

The `;`/`||` chaining shape is unchanged (no `if`/`then`/`fi` — the
`@yarnpkg/shell` emulator's grammar doesn't support POSIX control-flow
keywords, confirmed empirically in a past session). No new dependency
(e.g. `shx`) replaces the dropped call.

`docs/idd-policy.md`'s husky-to-`.githooks` migration section is
updated to match the new script, and now documents that any *future*
`.githooks/*` file must be committed with its executable bit already
set (e.g. `git update-index --chmod=+x <path>`), since `prepare` no
longer fixes this up at install time.

Closes #147

## Verification

- `git ls-files -s .githooks/pre-commit .githooks/pre-push
  .githooks/commit-msg` still reports `100755` for all three
  (unaffected by this change).
- Fresh `pnpm install` completes and `git config core.hooksPath`
  reports `.githooks` afterward.
- `pnpm run lint`, `pnpm run build`, and `pnpm run test` all pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated setup guidance to configure Git hooks without changing file permissions.
  - Clarified that hook scripts must already have executable permissions committed.
  - Documented that Git configuration errors are now reported instead of silently ignored.

- **Chores**
  - Simplified project setup to configure the Git hooks path only when running inside a Git repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->