### PR TITLE
chore: bumped the pnpm version

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "typescript": "~7.0.2",
     "vitest": "^4.1.0"
   },
-  "packageManager": "pnpm@11.15.1+sha512.81350b07e53c9538a02f1f2303b4290fa2d7be04e56e2a970c4cc4b417dc761de196edabd49d55c7dc9580db81007c44143e4e3d7e462b3000d23c255122d065",
+  "packageManager": "pnpm@11.21.0+sha512.521705bce689924eac72f5a3587122f362689ef6571e55ba80076fd637c11132ecffada26fad4ea79c485bfddbfd3d5a2a5b05805a77e893de71ec8a6cca3bb1",
   "engines": {
     "node": "^22.23.1 || ^24.2.0 || >=26.0.0"
   },


### PR DESCRIPTION
This pull request updates the `pnpm` package manager version in the `package.json` file to a newer release. No other changes are included.

- Dependency update:
  * Upgraded the `packageManager` field from `pnpm@11.15.1` to `pnpm@11.21.0` to ensure compatibility with the latest features and bug fixes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the pinned package manager version to 11.21.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->