### PR TITLE
fix(sea-builder): forward resolved --node to xsea

### DIFF
--- a/packages/sea-builder/CHANGELOG.md
+++ b/packages/sea-builder/CHANGELOG.md
@@ -32,6 +32,9 @@ project adheres to
 
 ### Fixed
 
+- Forwarded the resolved `--node` version to xsea as `-N` when linking
+  the SEA binary, so the emitted binary matches the version the cache
+  task downloaded instead of the Node.js running `sea-builder` (#155).
 - Restored CI signal on feature branches and pull requests, and
   aligned the `@vitest/coverage-v8` peer with `vitest` v4 (#68).
 - Fixed the `env` shebang with a multi-word argument on Linux by

--- a/packages/sea-builder/src/listr2/createBuildTasks.mts
+++ b/packages/sea-builder/src/listr2/createBuildTasks.mts
@@ -29,6 +29,7 @@ export const createBuildTasks = async (
   const { arch, platform = process.platform, projectRoot } = options;
   const { basename, download, execa, existsSync, mkdir, targets } =
     await normalizeBuildOptions(options);
+  const nodeVersion = await resolveNodeVersion(options.nodeVersion);
   return new Listr([
     createBuildTask(execa),
     createCacheTask({
@@ -36,11 +37,11 @@ export const createBuildTasks = async (
       download,
       existsSync,
       mkdir,
-      nodeVersion: await resolveNodeVersion(options.nodeVersion),
+      nodeVersion,
       platform,
       projectRoot,
       targets,
     }),
-    createSeaTask(execa, targets, basename),
+    createSeaTask(execa, targets, basename, nodeVersion),
   ]);
 };

--- a/packages/sea-builder/src/listr2/createBuildTasks.spec.mts
+++ b/packages/sea-builder/src/listr2/createBuildTasks.spec.mts
@@ -57,10 +57,17 @@ describe('createBuildTasks', () => {
     expect(mocks.resolveNodeVersion).toHaveBeenCalledWith('20');
   });
 
-  it('passes the resolved node version to createCacheTask', async () => {
+  it('resolves the node version once and forwards it to cache and sea tasks', async () => {
     await createBuildTasks({ basename: 'foo' });
+    expect(mocks.resolveNodeVersion).toHaveBeenCalledTimes(1);
     expect(mocks.createCacheTask).toHaveBeenCalledWith(
       expect.objectContaining({ nodeVersion: 'v22.23.2' }),
+    );
+    expect(mocks.createSeaTask).toHaveBeenCalledWith(
+      expect.anything(),
+      ['linux-x64'],
+      'foo',
+      'v22.23.2',
     );
   });
 });

--- a/packages/sea-builder/src/tasks/createSeaTask.mts
+++ b/packages/sea-builder/src/tasks/createSeaTask.mts
@@ -7,15 +7,23 @@ import type { Task } from './createTaskFactory.mjs';
  * @param execa The implementation of `execa` to use for running commands.
  * @param targets  Target platform strings.
  * @param basename Output file base name.
+ * @param nodeVersion Resolved Node.js version forwarded to xsea as `-N`.
  * @returns Listr task object.
  */
 export const createSeaTask = (
   execa: typeof concretedExeca,
   targets: readonly string[],
   basename: string,
+  nodeVersion: string,
 ): Task => {
   const additionalArgs = targets.flatMap((t) => ['-t', t]);
-  const args = [...XSEA_PREFIX_ARGS, `sea/${basename}`, ...additionalArgs];
+  const args = [
+    ...XSEA_PREFIX_ARGS,
+    `sea/${basename}`,
+    '-N',
+    nodeVersion,
+    ...additionalArgs,
+  ];
   return {
     title: 'Linking the SEA binary',
     task: () => execa('pnpm', args, { stdio: 'inherit' }),

--- a/packages/sea-builder/src/tasks/createSeaTask.spec.mts
+++ b/packages/sea-builder/src/tasks/createSeaTask.spec.mts
@@ -13,6 +13,7 @@ describe('createSeaTask', () => {
       runExeca as unknown as typeof execa,
       ['linux-x64', 'win32-x64'],
       'foo',
+      'v22.23.2',
     ).task();
     expect(calls[0]).toEqual([
       'pnpm',
@@ -22,6 +23,8 @@ describe('createSeaTask', () => {
         'dist/index.mjs',
         '-o',
         'sea/foo',
+        '-N',
+        'v22.23.2',
         '-t',
         'linux-x64',
         '-t',
@@ -31,7 +34,7 @@ describe('createSeaTask', () => {
   });
 
   it('sets title', () =>
-    expect(createSeaTask(vi.fn(), [], 'foo').title).toBe(
+    expect(createSeaTask(vi.fn(), [], 'foo', 'v22.23.2').title).toBe(
       'Linking the SEA binary',
     ));
 });


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/builder-config/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/builder-config/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/builder-config/blob/main/.github/CONTRIBUTING.zh.md
-->

## Summary

`sea-builder --node=<spec>` already resolved a concrete Node.js version
for the archive-download task, but never forwarded it to `xsea` when
linking. `xsea` then fell back to `'v' + process.versions.node`, so
the emitted binary could silently embed a different runtime than the
one advertised in the cache-task title.

This PR:

- Resolves the Node.js version once in `createBuildTasks` and passes
  the same value to both `createCacheTask` and `createSeaTask`.
- Emits `-N <resolved-version>` in the xsea argv after the `-o` output
  path and before the `-t` target pairs. `XSEA_PREFIX_ARGS` is
  unchanged.
- Updates the unit tests so the argv includes `-N` immediately
  followed by the resolved version, and so `resolveNodeVersion` is
  called exactly once with the identical value reaching both tasks.
- Records the user-facing fix in `packages/sea-builder/CHANGELOG.md`.

## IDD

- Issue: 155
- Claim: grok-01a0092c / 5f8790b8-6eeb-4fa3-8b41-18a0bd7c74ae
- Branch: `issue/155-sea-builder-s-node-is-not-forwarded-xsea`
- Plan: https://github.com/kurone-kito/builder-config/issues/155#issuecomment-5306077281
- Sibling isolation: `packages/sea-builder/package.json`,
  `pnpm-lock.yaml`, `normalizeTargets.mts` / spec, and README are
  untouched.

## Verification

- `pnpm run lint:fix` and `pnpm run lint` pass.
- `pnpm run lint && pnpm run build && pnpm run test` pass
  (81 tests).

## Recommended follow-up

None.

Closes #155