### PR TITLE
fix(sea-builder): normalize win32 targets to nodejs.org names

### DIFF
--- a/.cspell.config.yml
+++ b/.cspell.config.yml
@@ -7,6 +7,7 @@ import:
   - '@kurone-kito/cspell-config'
 version: '0.2'
 words:
+  - armv
   - dedup
   - deprioritize
   - desync

--- a/.cspell.config.yml
+++ b/.cspell.config.yml
@@ -7,7 +7,7 @@ import:
   - '@kurone-kito/cspell-config'
 version: '0.2'
 words:
-  - armv
+  - armv7l
   - dedup
   - deprioritize
   - desync

--- a/packages/sea-builder/CHANGELOG.md
+++ b/packages/sea-builder/CHANGELOG.md
@@ -32,9 +32,6 @@ project adheres to
 
 ### Fixed
 
-- Mapped `win32`, Windows `ia32`, and `arm` target names onto nodejs.org
-  archive vocabulary so default Windows builds and caller-supplied
-  `win32` targets no longer 404 (#154).
 - Forwarded the resolved `--node` version to xsea as `-N` when linking
   the SEA binary, so the emitted binary matches the version the cache
   task downloaded instead of the Node.js running `sea-builder` (#155).

--- a/packages/sea-builder/CHANGELOG.md
+++ b/packages/sea-builder/CHANGELOG.md
@@ -32,6 +32,9 @@ project adheres to
 
 ### Fixed
 
+- Mapped `win32`, Windows `ia32`, and `arm` target names onto nodejs.org
+  archive vocabulary so default Windows builds and caller-supplied
+  `win32` targets no longer 404 (#154).
 - Restored CI signal on feature branches and pull requests, and
   aligned the `@vitest/coverage-v8` peer with `vitest` v4 (#68).
 - Fixed the `env` shebang with a multi-word argument on Linux by

--- a/packages/sea-builder/README.md
+++ b/packages/sea-builder/README.md
@@ -18,7 +18,7 @@ and `sea-cache` for fetching Node.js archives used by the builder.
 
 ```sh
 sea-cache  # cache for current platform
-sea-cache linux-x64 win32-x64  # cache archives for multiple targets
+sea-cache linux-x64 win-x64  # cache archives for multiple targets
 ```
 
 Archives are downloaded to `node_modules/.cache/xsea` if not already
@@ -29,7 +29,7 @@ present.
 ```sh
 # <output> is the base name for the generated file under the `sea/` directory
 sea-builder my-cli                                # build for current platform
-sea-builder --targets=linux-x64,win32-x64 my-cli  # build for multiple targets
+sea-builder --targets=linux-x64,win-x64 my-cli  # build for multiple targets
 ```
 
 If no `--targets` option is given, the current platform and architecture
@@ -37,10 +37,13 @@ are used.
 
 ### Options
 
-Both commands accept target strings in the format `<platform>-<arch>` such
-as `linux-x64` or `win32-x64`. `sea-builder` automatically invokes
-`pnpm exec xsea` with the downloaded archives to create the binary under
-`sea/<output>`.
+Both commands accept target strings in the nodejs.org archive format
+`<platform>-<arch>` such as `linux-x64` or `win-x64`. When no target is
+given, the current Node.js platform and architecture are mapped onto that
+vocabulary (the Windows platform id becomes `win`, `ia32` becomes `x86`
+on Windows, and `arm` becomes `armv7l`). `sea-builder` automatically
+invokes `pnpm exec xsea` with the downloaded archives to create the
+binary under `sea/<output>`.
 
 `sea-builder` also accepts a `--node` option to choose the Node.js version.
 Omitting this option uses the latest patch of the oldest supported LTS line.

--- a/packages/sea-builder/README.md
+++ b/packages/sea-builder/README.md
@@ -38,8 +38,8 @@ are used.
 ### Options
 
 Both commands accept target strings in the nodejs.org archive format
-`<platform>-<arch>` such as `linux-x64` or `win-x64`. When no target is
-given, the current Node.js platform and architecture are mapped onto that
+`<platform>-<arch>` such as `linux-x64` or `win-x64`. Omitted targets
+and caller-supplied Node platform/arch spellings are mapped onto that
 vocabulary (the Windows platform id becomes `win`, `ia32` becomes `x86`
 on Windows, and `arm` becomes `armv7l`). `sea-builder` automatically
 invokes `pnpm exec xsea` with the downloaded archives to create the

--- a/packages/sea-builder/README.md
+++ b/packages/sea-builder/README.md
@@ -41,7 +41,7 @@ Both commands accept target strings in the nodejs.org archive format
 `<platform>-<arch>` such as `linux-x64` or `win-x64`. Omitted targets
 and caller-supplied Node platform/arch spellings are mapped onto that
 vocabulary (the Windows platform id becomes `win`, `ia32` becomes `x86`
-on Windows, and `arm` becomes `armv7l`). `sea-builder` automatically
+on Windows, and Linux `arm` becomes `armv7l`). `sea-builder` automatically
 invokes `pnpm exec xsea` with the downloaded archives to create the
 binary under `sea/<output>`.
 

--- a/packages/sea-builder/src/tasks/createCacheTasks.spec.mts
+++ b/packages/sea-builder/src/tasks/createCacheTasks.spec.mts
@@ -16,7 +16,7 @@ describe('createCacheTasks', () => {
     });
     expect(tasks).toHaveLength(2);
     expect(tasks[0]?.title).toBe('linux-x64');
-    expect(tasks[1]?.title).toBe('win32-x64');
+    expect(tasks[1]?.title).toBe('win-x64');
   });
 
   it('passes correct metadata to download', async () => {

--- a/packages/sea-builder/src/utils/normalizeTargets.mts
+++ b/packages/sea-builder/src/utils/normalizeTargets.mts
@@ -1,8 +1,37 @@
 /**
+ * Map a single `<platform>-<arch>` token onto nodejs.org archive names.
+ *
+ * Already-canonical names are a no-op so a second pass (for example
+ * `normalizeCacheOptions` re-entering through `createListrCacheTasks`)
+ * does not rewrite them again.
+ * @param target Target string such as `win32-x64` or `linux-arm`.
+ * @returns The nodejs.org archive target, e.g. `win-x64`.
+ */
+const toNodeArchiveTarget = (target: string): string => {
+  const separator = target.lastIndexOf('-');
+  if (separator === -1) {
+    return target;
+  }
+
+  const platform = target.slice(0, separator);
+  const arch = target.slice(separator + 1);
+  const mappedPlatform = platform === 'win32' ? 'win' : platform;
+  let mappedArch = arch;
+  if (mappedPlatform === 'win' && arch === 'ia32') {
+    mappedArch = 'x86';
+  } else if (arch === 'arm') {
+    mappedArch = 'armv7l';
+  }
+  return `${mappedPlatform}-${mappedArch}`;
+};
+
+/**
  * Normalize target list for SEA build.
  *
  * When {@link targets} is empty, this function falls back to the current
  * {@link platform} and {@link arch} to create a single target string.
+ * Every returned token is then mapped onto nodejs.org archive vocabulary
+ * (`win32` → `win`, Windows `ia32` → `x86`, `arm` → `armv7l`).
  * @param targets Target strings such as `linux-x64`.
  * @param platform Host platform name.
  * @param arch Host architecture name.
@@ -12,5 +41,7 @@ export const normalizeTargets = (
   targets: readonly string[],
   platform: NodeJS.Platform,
   arch: string,
-): readonly string[] =>
-  targets.length ? [...targets] : [`${platform}-${arch}` as const];
+): readonly string[] => {
+  const raw = targets.length ? targets : [`${platform}-${arch}`];
+  return raw.map(toNodeArchiveTarget);
+};

--- a/packages/sea-builder/src/utils/normalizeTargets.mts
+++ b/packages/sea-builder/src/utils/normalizeTargets.mts
@@ -5,7 +5,7 @@
  * `normalizeCacheOptions` re-entering through `createListrCacheTasks`)
  * does not rewrite them again.
  * @param target Target string such as `win32-x64` or `linux-arm`.
- * @returns The nodejs.org archive target, e.g. `win-x64`.
+ * @returns The nodejs.org archive target, e.g. `win-x64` or `linux-armv7l`.
  */
 const toNodeArchiveTarget = (target: string): string => {
   const separator = target.lastIndexOf('-');
@@ -19,7 +19,7 @@ const toNodeArchiveTarget = (target: string): string => {
   let mappedArch = arch;
   if (mappedPlatform === 'win' && arch === 'ia32') {
     mappedArch = 'x86';
-  } else if (arch === 'arm') {
+  } else if (mappedPlatform === 'linux' && arch === 'arm') {
     mappedArch = 'armv7l';
   }
   return `${mappedPlatform}-${mappedArch}`;
@@ -31,7 +31,7 @@ const toNodeArchiveTarget = (target: string): string => {
  * When {@link targets} is empty, this function falls back to the current
  * {@link platform} and {@link arch} to create a single target string.
  * Every returned token is then mapped onto nodejs.org archive vocabulary
- * (`win32` → `win`, Windows `ia32` → `x86`, `arm` → `armv7l`).
+ * (`win32` → `win`, Windows `ia32` → `x86`, Linux `arm` → `armv7l`).
  * @param targets Target strings such as `linux-x64`.
  * @param platform Host platform name.
  * @param arch Host architecture name.

--- a/packages/sea-builder/src/utils/normalizeTargets.spec.mts
+++ b/packages/sea-builder/src/utils/normalizeTargets.spec.mts
@@ -11,4 +11,49 @@ describe('normalizeTargets', () => {
       'darwin-arm64',
     ]);
   });
+
+  it('maps a derived win32 default to win', () => {
+    expect(normalizeTargets([], 'win32', 'x64')).toEqual(['win-x64']);
+  });
+
+  it('maps a caller-supplied win32 target to win', () => {
+    expect(normalizeTargets(['win32-arm64'], 'linux', 'x64')).toEqual([
+      'win-arm64',
+    ]);
+  });
+
+  it('maps a derived Windows ia32 default to x86', () => {
+    expect(normalizeTargets([], 'win32', 'ia32')).toEqual(['win-x86']);
+  });
+
+  it('maps a caller-supplied Windows ia32 target to x86', () => {
+    expect(normalizeTargets(['win32-ia32'], 'linux', 'x64')).toEqual([
+      'win-x86',
+    ]);
+  });
+
+  it('maps a derived arm default to armv7l', () => {
+    expect(normalizeTargets([], 'linux', 'arm')).toEqual(['linux-armv7l']);
+  });
+
+  it('maps a caller-supplied arm target to armv7l', () => {
+    expect(normalizeTargets(['linux-arm'], 'darwin', 'x64')).toEqual([
+      'linux-armv7l',
+    ]);
+  });
+
+  it('leaves an already-canonical target unchanged', () => {
+    expect(normalizeTargets(['win-x64'], 'linux', 'x64')).toEqual(['win-x64']);
+  });
+
+  it('does not map ia32 on non-Windows targets', () => {
+    expect(normalizeTargets(['linux-ia32'], 'linux', 'x64')).toEqual([
+      'linux-ia32',
+    ]);
+  });
+
+  it('is idempotent on its own output', () => {
+    const first = normalizeTargets(['win32-ia32', 'linux-arm'], 'win32', 'x64');
+    expect(normalizeTargets(first, 'win32', 'x64')).toEqual(first);
+  });
 });

--- a/packages/sea-builder/src/utils/normalizeTargets.spec.mts
+++ b/packages/sea-builder/src/utils/normalizeTargets.spec.mts
@@ -32,13 +32,22 @@ describe('normalizeTargets', () => {
     ]);
   });
 
-  it('maps a derived arm default to armv7l', () => {
+  it('maps a derived linux arm default to armv7l', () => {
     expect(normalizeTargets([], 'linux', 'arm')).toEqual(['linux-armv7l']);
   });
 
-  it('maps a caller-supplied arm target to armv7l', () => {
+  it('maps a caller-supplied linux arm target to armv7l', () => {
     expect(normalizeTargets(['linux-arm'], 'darwin', 'x64')).toEqual([
       'linux-armv7l',
+    ]);
+  });
+
+  it('does not map arm to armv7l on non-linux targets', () => {
+    expect(normalizeTargets(['win32-arm'], 'linux', 'x64')).toEqual([
+      'win-arm',
+    ]);
+    expect(normalizeTargets(['darwin-arm'], 'linux', 'x64')).toEqual([
+      'darwin-arm',
     ]);
   });
 


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/builder-config/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/builder-config/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/builder-config/blob/main/.github/CONTRIBUTING.zh.md
-->

## Summary

`sea-builder` and `sea-cache` built Node.js archive URLs from
`<platform>-<arch>` strings, including the raw `process.platform`
value. On Windows that is `win32`, but nodejs.org publishes `win-*`
archives, so a default Windows run 404ed.

This PR:

- Maps every target in `normalizeTargets` onto nodejs.org vocabulary
  (`win32` → `win`, Windows `ia32` → `x86`, Linux `arm` → `armv7l`) for
  both the derived default and each caller-supplied string.
- Keeps already-canonical names as a no-op so the second
  `normalizeCacheOptions` pass stays idempotent.
- Documents `win-x64` in `packages/sea-builder/README.md`.

Changelog notes for this fix are batched at the next release cut, not
in this PR.

## IDD

- Issue: #154
- Claim: grok-01a0092c / 65da5643-715b-493d-988b-32316643ab9e
- Branch: `issue/154-fix-sea-builder-s-windows-target-names`
- Plan: https://github.com/kurone-kito/builder-config/issues/154#issuecomment-5306079256
- Sibling isolation: `packages/sea-builder/package.json`,
  `pnpm-lock.yaml`, `createBuildTasks.mts`, `createSeaTask.mts`, and
  their specs are untouched.

## Verification

- `pnpm run lint:fix` and `pnpm run lint` pass.
- `pnpm run lint && pnpm run build && pnpm run test` pass.

## Recommended follow-up

None.

Closes #154