### PR TITLE
fix(deps): pin @types/jsdom's unconstrained @types/node dependency

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  '@types/jsdom>@types/node': ^24.6.2
   adm-zip: ^0.6.0
   nanoid: ^3.3.17
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,6 +9,16 @@ gitChecks: false
 ignoreWorkspaceRootCheck: true
 linkWorkspacePackages: true
 overrides:
+  # Pin @types/jsdom's own @types/node dependency: @types/jsdom
+  # declares it as an unconstrained '*' dependency (not a peer), so a
+  # fresh pnpm resolve can flip which @types/node flavor satisfies it
+  # workspace-wide whenever the dependency graph changes elsewhere
+  # (e.g. an unrelated devDependency bump) -- silently producing
+  # duplicate-identifier TypeScript errors. Matches vite-lib-config's
+  # own @types/node range so the pin stays consistent with an
+  # existing intentional flavor rather than introducing a third
+  # value.
+  '@types/jsdom>@types/node': '^24.6.2'
   # Transitive-only pin: xsea's own adm-zip range (^0.5.16) predates the
   # GHSA-xcpc-8h2w-3j85 fix. Drop once xsea widens its own adm-zip
   # dependency to include >=0.6.0.

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,7 +17,8 @@ overrides:
   # duplicate-identifier TypeScript errors. Matches vite-lib-config's
   # own @types/node range so the pin stays consistent with an
   # existing intentional flavor rather than introducing a third
-  # value.
+  # value. Keep in sync with vite-lib-config's own range; revisit
+  # once #125 unifies @types/node workspace-wide.
   '@types/jsdom>@types/node': '^24.6.2'
   # Transitive-only pin: xsea's own adm-zip range (^0.5.16) predates the
   # GHSA-xcpc-8h2w-3j85 fix. Drop once xsea widens its own adm-zip


### PR DESCRIPTION
## Summary

Pins `@types/jsdom`'s own `@types/node` dependency via a scoped pnpm
override (`'@types/jsdom>@types/node': '^24.6.2'` in
`pnpm-workspace.yaml`'s `overrides` block), so pnpm resolves it
deterministically instead of picking it up based on dependency-graph
traversal order. `pnpm-lock.yaml` is regenerated to record the
override.

`@types/jsdom` declares its own `@types/node` dependency as an
unconstrained `'*'` range (a regular dependency, not a peer — verified
against the lockfile: the `@types/jsdom@30.0.0` snapshot lists
`@types/node` under a plain `dependencies:` key with no peer-suffixed
resolution). A fresh `pnpm install` can silently flip which
`@types/node` flavor satisfies that `'*'` range whenever the
dependency graph changes elsewhere in the workspace — even from an
unrelated devDependency bump — producing duplicate-identifier
TypeScript errors (`TS2300`/`TS2451`/`TS2305`) against `@types/node`'s
ambient globals. This exact break was previously observed while
evaluating issue #161's `@kurone-kito/idd-skill` pin bump. The pin
here matches `packages/vite-lib-config`'s own `@types/node` range
(`^24.6.2`), so it stays consistent with an existing intentional
flavor already used elsewhere in the workspace.

### Verification scope (please read before reviewing)

This is a **preventive/deterministic pin**, not a reproduce-and-fix
change. On this branch's `main` baseline, `@types/jsdom@30.0.0`
already resolves a single, consistent `@types/node@24.13.3`
throughout `pnpm-lock.yaml` — the duplicate-identifier break is not
currently manifest here, which is why the lockfile diff below is only
one line (the new `overrides:` record itself; no snapshot changes).
The break only appears under a separate devDependency-graph
perturbation (issue #161's pin bump), which is out of scope to
reproduce in this PR. What this PR verifies directly:

- the override syntax is valid and pnpm records it correctly in the
  regenerated lockfile;
- every `@types/jsdom@*` snapshot resolves `@types/node` to the same
  value throughout the file (still true, and now pinned rather than
  incidental);
- neither `packages/sea-builder`'s (`^26.2.0`) nor
  `packages/vite-lib-config`'s own `@types/node` range is touched;
- the full acceptance suite passes clean on the regenerated lockfile.

## Changes

- `pnpm-workspace.yaml`: new `overrides` entry pinning
  `@types/jsdom>@types/node`, with a comment explaining the
  unconstrained-dependency mechanism and a revisit trigger tied to
  #125 (workspace-wide `@types/node` unification, currently blocked
  on #120's TypeScript 7 migration).
- `pnpm-lock.yaml`: regenerated; the only change is the new override
  record itself.

## Verification

- `pnpm install --frozen-lockfile` — succeeds against the regenerated
  lockfile.
- `pnpm run lint:fix` then `pnpm run lint` — both pass clean.
- `pnpm run build` — passes.
- `pnpm run test` (including `test:ts`, `tsc --noEmit`) — 91/91
  vitest tests pass, `test:ts` exits 0 with no duplicate-identifier or
  "no exported member" errors.

## Non-goals

Does not touch `packages/sea-builder/package.json`'s or
`packages/vite-lib-config/package.json`'s own `@types/node` ranges —
unifying those across packages remains #125's separate, still-blocked
scope (blocked on #120's upstream typedoc constraint).

Closes #167
