### PR TITLE
chore(deps): bump idd-skill helper pin to v0.7.0

### DIFF
--- a/.github/idd/config.json
+++ b/.github/idd/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://kurone-kito.github.io/idd-skill/schemas/policy.schema.json",
-  "iddVersion": "0.6.0",
+  "iddVersion": "0.7.0",
   "markerPrefix": "builder-config",
   "mergePolicy": "fully_autonomous_merge",
   "reviewPolicy": "copilot-advisory",

--- a/.github/idd/config.json
+++ b/.github/idd/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://kurone-kito.github.io/idd-skill/schemas/policy.schema.json",
-  "iddVersion": "0.7.0",
+  "iddVersion": "0.6.0",
   "markerPrefix": "builder-config",
   "mergePolicy": "fully_autonomous_merge",
   "reviewPolicy": "copilot-advisory",

--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -175,12 +175,11 @@ the npm registry**; its default dependency spec is a moving
 to a reviewed commit archive for reproducibility:
 
 ```text
-https://codeload.github.com/kurone-kito/idd-skill/tar.gz/83d5f2ae1e6502d95c3d675f807574c42742ef4d
+https://codeload.github.com/kurone-kito/idd-skill/tar.gz/f51a8bb73a47452eff5799e8a27251b660ba4ae0
 ```
 
-(idd-skill commit `83d5f2a`, an unreleased `main` snapshot past
-`v0.6.0` — no newer tag exists yet; `@kurone-kito/idd-skill@0.6.0`.)
-Bump this pin deliberately (re-run
+(idd-skill commit `f51a8bb7`, tagged `v0.7.0` on 2026-08-20;
+`@kurone-kito/idd-skill@0.7.0`.) Bump this pin deliberately (re-run
 `idd-helper-bundle-manifest --profile package-manager --package-spec <new-pin>`
 from a newer idd-skill clone) rather than letting it drift to `main`.
 

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "@kurone-kito/commitlint-config": "^0.22.0",
     "@kurone-kito/cspell-config": "^0.22.0",
     "@kurone-kito/example-cli": "workspace:^",
-    "@kurone-kito/idd-skill": "https://codeload.github.com/kurone-kito/idd-skill/tar.gz/83d5f2ae1e6502d95c3d675f807574c42742ef4d",
+    "@kurone-kito/idd-skill": "https://codeload.github.com/kurone-kito/idd-skill/tar.gz/f51a8bb73a47452eff5799e8a27251b660ba4ae0",
     "@kurone-kito/is-prerelease": "^0.1.0",
     "@kurone-kito/lint-staged-config": "^0.22.0",
     "@kurone-kito/markdownlint-config": "^0.22.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,8 +63,8 @@ importers:
         specifier: workspace:^
         version: link:packages/example-cli
       '@kurone-kito/idd-skill':
-        specifier: https://codeload.github.com/kurone-kito/idd-skill/tar.gz/83d5f2ae1e6502d95c3d675f807574c42742ef4d
-        version: https://codeload.github.com/kurone-kito/idd-skill/tar.gz/83d5f2ae1e6502d95c3d675f807574c42742ef4d
+        specifier: https://codeload.github.com/kurone-kito/idd-skill/tar.gz/f51a8bb73a47452eff5799e8a27251b660ba4ae0
+        version: https://codeload.github.com/kurone-kito/idd-skill/tar.gz/f51a8bb73a47452eff5799e8a27251b660ba4ae0
       '@kurone-kito/is-prerelease':
         specifier: ^0.1.0
         version: 0.1.0
@@ -729,10 +729,10 @@ packages:
       cspell:
         optional: true
 
-  '@kurone-kito/idd-skill@https://codeload.github.com/kurone-kito/idd-skill/tar.gz/83d5f2ae1e6502d95c3d675f807574c42742ef4d':
-    resolution: {gitHosted: true, integrity: sha512-gBKl9x5N2bYag0SPG0o9UEYtvVXsXnEwJJfgn7mr+OaJJluhACrwEFKK/+3za8NJl/WNSZG54NQhhlc7lYyWZQ==, tarball: https://codeload.github.com/kurone-kito/idd-skill/tar.gz/83d5f2ae1e6502d95c3d675f807574c42742ef4d}
-    version: 0.6.0
-    engines: {node: ^22.22.2 || >=24.2.0}
+  '@kurone-kito/idd-skill@https://codeload.github.com/kurone-kito/idd-skill/tar.gz/f51a8bb73a47452eff5799e8a27251b660ba4ae0':
+    resolution: {tarball: https://codeload.github.com/kurone-kito/idd-skill/tar.gz/f51a8bb73a47452eff5799e8a27251b660ba4ae0}
+    version: 0.7.0
+    engines: {node: ^22.23.2 || ^24.2.0 || >=26.0.0}
     hasBin: true
 
   '@kurone-kito/is-prerelease@0.1.0':
@@ -3036,7 +3036,7 @@ snapshots:
     optionalDependencies:
       cspell: 10.0.1
 
-  '@kurone-kito/idd-skill@https://codeload.github.com/kurone-kito/idd-skill/tar.gz/83d5f2ae1e6502d95c3d675f807574c42742ef4d': {}
+  '@kurone-kito/idd-skill@https://codeload.github.com/kurone-kito/idd-skill/tar.gz/f51a8bb73a47452eff5799e8a27251b660ba4ae0': {}
 
   '@kurone-kito/is-prerelease@0.1.0':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -730,7 +730,7 @@ packages:
         optional: true
 
   '@kurone-kito/idd-skill@https://codeload.github.com/kurone-kito/idd-skill/tar.gz/f51a8bb73a47452eff5799e8a27251b660ba4ae0':
-    resolution: {tarball: https://codeload.github.com/kurone-kito/idd-skill/tar.gz/f51a8bb73a47452eff5799e8a27251b660ba4ae0}
+    resolution: {gitHosted: true, integrity: sha512-tVKS/nOQ45SAsLjm9zmiGcgmgeXuZFLVeW1vSDyJYUfYon5aPGKlW5NJxQ55tjSkxX2QJ7ZDXQDGfaKXJnDKgg==, tarball: https://codeload.github.com/kurone-kito/idd-skill/tar.gz/f51a8bb73a47452eff5799e8a27251b660ba4ae0}
     version: 0.7.0
     engines: {node: ^22.23.2 || ^24.2.0 || >=26.0.0}
     hasBin: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,5 @@
 allowBuilds:
-  '@kurone-kito/idd-skill@https://codeload.github.com/kurone-kito/idd-skill/tar.gz/83d5f2ae1e6502d95c3d675f807574c42742ef4d': true
+  '@kurone-kito/idd-skill@https://codeload.github.com/kurone-kito/idd-skill/tar.gz/f51a8bb73a47452eff5799e8a27251b660ba4ae0': true
   esbuild: true
 configDependencies:
   '@pnpm/plugin-types-fixer': 0.1.0+sha512-bLww63gRHi7siYTqFJb5qNdcXadU0jv20Et6z5AryMZ7FlLolbEJOrXLpg8+amQZNHHNW1dfFUBGVw/9ezQbFg==


### PR DESCRIPTION
## Summary

Bumps the reviewed `@kurone-kito/idd-skill` archive pin from the
unreleased `83d5f2a` `main` snapshot to the tagged **`v0.7.0`** release
(`f51a8bb73a47452eff5799e8a27251b660ba4ae0`), which lands the
`review-ack` marker type needed to recover from the required-check
stall class seen on PR #159 (the `review-ack:` recovery path from
upstream kurone-kito/idd-skill#2050 / kurone-kito/idd-skill#2054 does
not exist in the old pin).

## Changes

- `package.json`: `devDependencies["@kurone-kito/idd-skill"]` codeload
  URL bumped to the `v0.7.0` tag commit.
- `pnpm-workspace.yaml`: `allowBuilds` key updated to the new exact
  package-spec string (build-approval is keyed by the exact spec
  including the commit SHA — the old-SHA entry is dropped, not kept
  alongside the new one, avoiding the
  `ERR_PNPM_GIT_DEP_PREPARE_NOT_ALLOWED` gotcha from issue #135).
- `docs/idd-policy.md`: Helper Runtime Profile section's quoted SHA,
  date, and version note updated to match `package.json`.
- `pnpm-lock.yaml`: regenerated against the new pin.

## Deviation from issue #161's acceptance criterion #6

Issue #161's AC #6 asked for `.github/idd/config.json`'s `iddVersion`
to be bumped from `"0.6.0"` to `"0.7.0"` alongside the helper pin.
`chatgpt-codex-connector` flagged in review that this criterion is
itself wrong against documented repository policy:
`docs/customization.md`'s "Template Version and Staleness" section
defines `iddVersion` as tracking **which release of the distributed
IDD workflow (the imported instruction bundle) this repository
imported** — a separate concept from the helper package pin bumped
here — and `idd-doctor` uses it for staleness comparisons. Bumping it
in this helper-only commit would make the still-unreconciled v0.6.0
instruction bundle appear current and suppress that re-sync signal.
Verified the claim directly against `docs/customization.md` and
accepted the finding; `iddVersion` stays `"0.6.0"` in this PR (see
[the resolved thread](https://github.com/kurone-kito/builder-config/pull/169#discussion_r3818729705)
and commit 9987135). The imported-bundle reconciliation itself stays
out of scope here, tracked separately under roadmap #162 (issue #164).

## Verification scope (please read before reviewing)

This issue's implementation was originally completed and held: the
pin bump itself perturbed pnpm's dependency resolution enough to flip
which `@types/node` flavor satisfied `@types/jsdom`'s (then
unconstrained) `@types/node` dependency, breaking `test:ts` in
`packages/example-lib` with duplicate-identifier errors — unrelated
to this issue's own scope. That was root-caused and fixed separately
in #167 (merged as PR #168), which pins `@types/jsdom>@types/node` via
a scoped `pnpm.overrides` entry. This PR reconciles the originally-held
work onto `main` with #168 included and re-verifies the fix actually
resolves the original break:

- `pnpm install --frozen-lockfile` — succeeds against the regenerated
  lockfile.
- `pnpm run lint:fix` then `pnpm run lint` — both pass clean.
- `pnpm run build` — passes.
- **`pnpm run test` (including `test:ts`, `tsc --noEmit`) — 91/91
  vitest tests pass, `test:ts` exits 0 with no duplicate-identifier or
  "no exported member" errors** — confirms #167's override actually
  fixes this pin bump's specific break, not just a synthetic
  reproduction.
- `pnpm exec idd-post-idd-marker --help` lists `review-ack` as a
  `--type` (confirmed absent before the bump, present after).
- Ancestry of the `review-ack` helper merge commit (`0bf046d8`) into
  the new pin (`f51a8bb7...`) verified via GitHub's compare API
  against the `idd-skill` repository (`behind_by: 0`, `status:
  "ahead"`), since the local worktree has no `idd-skill` git history
  for a direct `git merge-base --is-ancestor` check.
- No stray `83d5f2a` references remain anywhere in the tree.

## Non-goals

Does not change merge policy, review policy, or this repository's
CHANGELOG rule, and does not rewrite imported
`.github/instructions/*.instructions.md` content — that reconciliation,
plus the issue-authoring bundle and the advisory-convergence workflow
hardening, are tracked as separate, blocked-by-this tracks under
roadmap #162.

Closes #161

