### PR TITLE
ci(workflows): split idd-advisory-convergence comment trigger

### DIFF
--- a/.cspell.config.yml
+++ b/.cspell.config.yml
@@ -13,6 +13,7 @@ words:
   - desync
   - desynced
   - Esync
+  - GHES
   - GHSA
   - isort
   - onnx

--- a/.github/workflows/idd-advisory-convergence-comment.yml
+++ b/.github/workflows/idd-advisory-convergence-comment.yml
@@ -1,0 +1,92 @@
+# Non-required companion to idd-advisory-convergence.yml (#163, matching
+# kurone-kito/idd-skill#2136).
+#
+# Human review-thread chatter must not create or cancel the required
+# `idd-advisory-convergence` check-run. This workflow has a different
+# name, job id, and concurrency group so it structurally cannot
+# overwrite that SHA's verdict or cancel an in-flight required run:
+# `name:` below is a different string than "IDD advisory-convergence
+# gate", so `${{ github.workflow }}` differs, so the concurrency group
+# differs even for the same PR number; the job id
+# (`refresh-if-idd-originated`) is a different check-run context than
+# `idd-advisory-convergence`, so this job's own runs never appear on
+# the required check's rollup at all.
+#
+# When the comment is IDD-originated (reply-identity stamp, disposition
+# prefix, or an operational marker the required check already honors),
+# it reuses `idd-rerun-advisory-convergence --apply` to refresh the
+# existing pull_request-family required run for the current HEAD SHA.
+# It never asserts `ready` itself -- an ordinary human reply (e.g.
+# "LGTM") classifies as not IDD-originated and this workflow takes no
+# action on the required check at all.
+#
+# Job id is deliberately NOT `idd-advisory-convergence`.
+concurrency:
+  # Do not cancel: a later human LGTM must not abort an in-flight
+  # IDD-originated refresh before it reruns the required check (#163).
+  cancel-in-progress: false
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+name: IDD advisory-convergence comment refresh
+on:
+  pull_request_review_comment:
+    types: [created, edited, deleted]
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+  # Needed for the rerun step's Actions API call
+  # (idd-rerun-advisory-convergence --apply reruns an existing workflow
+  # run for the required job).
+  actions: write
+jobs:
+  refresh-if-idd-originated:
+    runs-on: ubuntu-slim
+    timeout-minutes: 10
+    steps:
+      # Trusted default-branch checkout, not the PR head -- same
+      # rationale as idd-advisory-convergence.yml's own checkout step:
+      # a PR must not be able to edit the classifier or its config
+      # (.github/idd/config.json) to force a false idd_originated
+      # verdict.
+      - name: Stages the main branch
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: main
+          persist-credentials: false
+      - name: Setup the pnpm
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+        with:
+          run_install: false
+      - name: Prepare the Node.js environment
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          cache: pnpm
+          check-latest: true
+          node-version-file: .node-version
+      - name: Install the dependencies
+        run: pnpm install --frozen-lockfile --prefer-offline
+      - env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
+        name: Classify review comment
+        id: origin
+        # review-comment-origin.mjs ships in @kurone-kito/idd-skill@0.7.0
+        # as a plain vendored script only -- confirmed no
+        # `idd-review-comment-origin` bin/CLI facade exists at this pin
+        # (absent from both the package's own `bin` field and this
+        # repository's package.json `idd:*` script map), unlike
+        # idd-rerun-advisory-convergence below, which does have one. It
+        # is a workflow-embedded classifier (reads $COMMENT_BODY, writes
+        # $GITHUB_OUTPUT), never an agent-facing CLI helper, so there is
+        # no `pnpm exec idd-*` form to fall back to here -- this is the
+        # package-manager-profile equivalent of upstream's own
+        # `node scripts/review-comment-origin.mjs` invocation.
+        run: node node_modules/@kurone-kito/idd-skill/scripts/review-comment-origin.mjs
+      - if: steps.origin.outputs.idd_originated == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          # Single github.com host only (this repository is not GHES),
+          # matching idd-advisory-convergence.yml's own required job,
+          # which also sets only GH_TOKEN.
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        name: Rerun required HEAD check
+        run: pnpm exec idd-rerun-advisory-convergence --pr "$PR_NUMBER" --apply

--- a/.github/workflows/idd-advisory-convergence-comment.yml
+++ b/.github/workflows/idd-advisory-convergence-comment.yml
@@ -87,7 +87,22 @@ jobs:
         # package-manager-profile equivalent of upstream's own
         # `node scripts/review-comment-origin.mjs` invocation.
         run: node node_modules/@kurone-kito/idd-skill/scripts/review-comment-origin.mjs
-      - if: steps.origin.outputs.idd_originated == 'true'
+      - if: github.event.action == 'edited' && steps.origin.outputs.idd_originated != 'true'
+        env:
+          COMMENT_BODY: ${{ github.event.changes.body.from }}
+        name: Classify previous comment body (edited events only)
+        id: origin_prev
+        # An edit that strips an IDD marker (reply stamp, disposition
+        # prefix, operational marker) from a comment that previously had
+        # one must still refresh the required check: the earlier
+        # created/edited trigger may have already made it pass based on
+        # state the edit just retracted (Copilot review #170 on this
+        # PR). github.event.changes.body.from carries the pre-edit text
+        # for a GitHub comment-edit webhook; only checked when the new
+        # body alone didn't already classify as IDD-originated, to avoid
+        # a redundant second classify call.
+        run: node node_modules/@kurone-kito/idd-skill/scripts/review-comment-origin.mjs
+      - if: steps.origin.outputs.idd_originated == 'true' || steps.origin_prev.outputs.idd_originated == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           # Single github.com host only (this repository is not GHES),

--- a/.github/workflows/idd-advisory-convergence-comment.yml
+++ b/.github/workflows/idd-advisory-convergence-comment.yml
@@ -40,7 +40,13 @@ permissions:
   actions: write
 jobs:
   refresh-if-idd-originated:
-    runs-on: ubuntu-slim
+    # No `runner` workflow_dispatch input here (this workflow only
+    # triggers on pull_request_review_comment, never manually
+    # dispatched), but still honors the CI_RUNNER_LABEL escape hatch so
+    # a self-hosted-runner requirement (e.g. GHES) covers this job too,
+    # not only the required idd-advisory-convergence job (#163 C1
+    # follow-up).
+    runs-on: ${{ vars.CI_RUNNER_LABEL || 'ubuntu-slim' }}
     timeout-minutes: 10
     steps:
       # Trusted default-branch checkout, not the PR head -- same

--- a/.github/workflows/idd-advisory-convergence.yml
+++ b/.github/workflows/idd-advisory-convergence.yml
@@ -42,13 +42,17 @@ jobs:
   # give this job an explicit `name:` override, or those lookups silently
   # find zero check-run instances.
   idd-advisory-convergence:
-    # Overridable via the workflow_dispatch `runner` input, falling
-    # back to the CI_RUNNER_LABEL repository variable, then the
-    # ubuntu-slim default -- same precedence idd-skill's own
+    # Overridable via the workflow_dispatch `runner` input, or via the
+    # CI_RUNNER_LABEL repository variable for the pull_request /
+    # pull_request_review triggers (which carry no `inputs` context,
+    # so `inputs.runner` is empty and this falls through to the
+    # variable/default there). Note: CI_RUNNER_LABEL has no effect on
+    # a manual workflow_dispatch run specifically, since `runner`'s
+    # own `default: ubuntu-slim` means `inputs.runner` is never empty
+    # there -- pass the desired label directly to the `runner` input
+    # on a manual dispatch instead. Same precedence idd-skill's own
     # idd-template/.github/workflows/idd-advisory-convergence.yml
-    # documents (#163). pull_request / pull_request_review triggers
-    # carry no `inputs` context, so `inputs.runner` is empty for them
-    # and this falls straight through to the variable/default.
+    # documents (#163).
     runs-on: ${{ inputs.runner || vars.CI_RUNNER_LABEL || 'ubuntu-slim' }}
     timeout-minutes: 10
     steps:

--- a/.github/workflows/idd-advisory-convergence.yml
+++ b/.github/workflows/idd-advisory-convergence.yml
@@ -1,25 +1,33 @@
 name: IDD advisory-convergence gate
 concurrency:
   cancel-in-progress: true
-  # Grouped by PR number, not github.ref: pull_request_review and
-  # pull_request_review_comment are not pull_request-family events, so
-  # github.ref does not resolve the same way for them as it does for a
-  # pull_request-only workflow. workflow_dispatch has no pull_request
-  # context either, so it falls back to its own input.
+  # Grouped by PR number, not github.ref: pull_request_review is not a
+  # pull_request-family event, so github.ref does not resolve the same
+  # way for it as it does for a pull_request-only workflow.
+  # Review-thread comments used to share this trigger set too, but they
+  # now live in the separate idd-advisory-convergence-comment.yml
+  # companion workflow (#163, matching kurone-kito/idd-skill#2136): its
+  # own distinct `name:` gives it a distinct ${{ github.workflow }},
+  # hence a distinct concurrency group here, so it can never cancel or
+  # queue against this required job's own runs. workflow_dispatch has
+  # no pull_request context either, so it falls back to its own input.
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || inputs.pr_number }}
 on:
   pull_request:
     types: [opened, reopened, synchronize]
   pull_request_review:
     types: [submitted]
-  pull_request_review_comment:
-    types: [created, edited, deleted]
   workflow_dispatch:
     inputs:
       pr_number:
         description: PR number to re-check (e.g. after posting a maintainer waiver)
         required: true
         type: number
+      runner:
+        description: Runner label (default ubuntu-slim)
+        required: false
+        type: string
+        default: ubuntu-slim
 permissions:
   contents: read
   issues: read
@@ -34,7 +42,14 @@ jobs:
   # give this job an explicit `name:` override, or those lookups silently
   # find zero check-run instances.
   idd-advisory-convergence:
-    runs-on: ubuntu-latest
+    # Overridable via the workflow_dispatch `runner` input, falling
+    # back to the CI_RUNNER_LABEL repository variable, then the
+    # ubuntu-slim default -- same precedence idd-skill's own
+    # idd-template/.github/workflows/idd-advisory-convergence.yml
+    # documents (#163). pull_request / pull_request_review triggers
+    # carry no `inputs` context, so `inputs.runner` is empty for them
+    # and this falls straight through to the variable/default.
+    runs-on: ${{ inputs.runner || vars.CI_RUNNER_LABEL || 'ubuntu-slim' }}
     timeout-minutes: 10
     steps:
       # Trusted default-branch checkout, not the PR head, for any trigger

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -386,12 +386,14 @@ once `ciGate.externalCheckWaivers.mode` is `maintainer-authorized`
 external check never silently makes this one waivable too. **Posting a
 waiver comment does not by itself turn the check green**: a waiver is a
 regular PR comment, which is not one of the workflow's triggers
-(`pull_request` push, `pull_request_review` submission, or
-`pull_request_review_comment` created/edited/deleted on a review
-thread), so after posting a waiver a maintainer must also **re-run the
+(`pull_request` push or `pull_request_review` submission), so after
+posting a waiver a maintainer must also **re-run the
 existing** PR-linked check run **for the current HEAD SHA** — the
 Actions UI "Re-run jobs" button, or `gh run rerun <run-id>` — for the
-required check to actually reflect it. `workflow_dispatch` does
+required check to actually reflect it. An IDD-originated review-thread
+comment refreshes that same HEAD run via the companion
+`idd-advisory-convergence-comment.yml` workflow instead (issue #163,
+matching `kurone-kito/idd-skill#2136`). `workflow_dispatch` does
 **not** reliably do this:
 a dispatched run has no `pull_request` context of its own, so GitHub
 associates it with the dispatch ref rather than the PR's HEAD SHA, and

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -386,7 +386,8 @@ once `ciGate.externalCheckWaivers.mode` is `maintainer-authorized`
 external check never silently makes this one waivable too. **Posting a
 waiver comment does not by itself turn the check green**: a waiver is a
 regular PR comment, which is not one of the workflow's triggers
-(`pull_request` push or `pull_request_review` submission), so after
+(`pull_request` push, `pull_request_review` submission, or a manually
+dispatched `workflow_dispatch`), so after
 posting a waiver a maintainer must also **re-run the
 existing** PR-linked check run **for the current HEAD SHA** — the
 Actions UI "Re-run jobs" button, or `gh run rerun <run-id>` — for the

--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -365,8 +365,9 @@ confirmed empirically on this PR after the job briefly carried a
 **Waiver re-trigger procedure**: posting a maintainer waiver comment
 does **not** by itself turn this check green — a PR conversation
 comment fires GitHub's `issue_comment` event, which this workflow does
-not listen for (only `pull_request` and `pull_request_review`, since
-issue #163), and a completed run's conclusion never changes on its
+not listen for (only `pull_request`, `pull_request_review`, and a
+manually dispatched `workflow_dispatch`, since issue #163), and a
+completed run's conclusion never changes on its
 own. After posting a waiver, also trigger a new
 run: a push, a fresh Copilot review, the Actions UI "Re-run jobs"
 button on the *existing* PR-linked run for the *current HEAD SHA*, or

--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -328,6 +328,29 @@ its own SHA-pinned action conventions (matching `push-feature.yml`/
 `workflow_dispatch`. Registering it as a **required** status check is
 maintainer-only work tracked in #51, not part of this issue.
 
+**Trigger split (issue #163, matching `kurone-kito/idd-skill#2136`,
+shipped in `v0.7.0`)**: this workflow no longer triggers on
+`pull_request_review_comment`. That trigger now lives on a separate,
+non-required companion workflow,
+`.github/workflows/idd-advisory-convergence-comment.yml`, with its own
+job id, workflow `name:`, and concurrency group, so an ordinary human
+review-thread reply can no longer create or cancel this required
+check's rollup for the PR HEAD. The companion classifies the
+triggering comment and only reruns this workflow's existing run via
+`idd-rerun-advisory-convergence --apply` when the comment is
+IDD-originated; it never asserts `ready` itself. This workflow's CI
+runner is also overridable now, via a `runner` `workflow_dispatch`
+input defaulting to `ubuntu-slim` (falling back to the `CI_RUNNER_LABEL`
+repository variable), replacing the previously hardcoded
+`runs-on: ubuntu-latest` — adopted from
+`idd-template/.github/workflows/idd-advisory-convergence.yml`'s
+documented precedence rather than from `idd-skill`'s own dogfooded
+root copy, which hardcodes `ubuntu-slim` with no override input at
+all. This repository's copy is therefore a deliberate hybrid of the
+two upstream shapes (the split from the dogfooded copy, the runner
+override from the template copy), not a byte-for-byte mirror of
+either.
+
 The job intentionally carries no `name:` override, unlike this
 repository's other jobs — its id, `idd-advisory-convergence`, is also
 the check-run name the `idd-rerun-advisory-convergence` helper and the
@@ -342,12 +365,16 @@ confirmed empirically on this PR after the job briefly carried a
 **Waiver re-trigger procedure**: posting a maintainer waiver comment
 does **not** by itself turn this check green — a PR conversation
 comment fires GitHub's `issue_comment` event, which this workflow does
-not listen for (only `pull_request_review_comment`, scoped to comments
-on the diff), and a completed run's conclusion never changes on its
+not listen for (only `pull_request` and `pull_request_review`, since
+issue #163), and a completed run's conclusion never changes on its
 own. After posting a waiver, also trigger a new
 run: a push, a fresh Copilot review, the Actions UI "Re-run jobs"
 button on the *existing* PR-linked run for the *current HEAD SHA*, or
-`gh run rerun <run-id>` on that same run. **`workflow_dispatch` does
+`gh run rerun <run-id>` on that same run. An IDD-originated
+review-thread comment refreshes that same HEAD run via the companion
+`idd-advisory-convergence-comment.yml` workflow instead — an ordinary
+human waiver-adjacent reply (e.g. "waived, see above") does not, by
+design. **`workflow_dispatch` does
 NOT reliably do this**: a dispatched run has no `pull_request` context
 of its own, so GitHub associates it with the dispatch ref rather than
 the PR's HEAD SHA, and the resulting run's conclusion can be invisible


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/builder-config/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/builder-config/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/builder-config/blob/main/.github/CONTRIBUTING.zh.md
-->

## Summary

- Split `.github/workflows/idd-advisory-convergence.yml`'s
  `pull_request_review_comment` trigger into a new, non-required
  companion workflow, `.github/workflows/idd-advisory-convergence-comment.yml`
  (matching `kurone-kito/idd-skill#2136`, shipped in `v0.7.0`), so an
  ordinary human review-thread reply can no longer create or cancel
  the required `idd-advisory-convergence` check's rollup for the PR
  HEAD. The companion has its own job id
  (`refresh-if-idd-originated`), workflow `name:`, and concurrency
  group, classifies the triggering comment via `review-comment-origin.mjs`,
  and only reruns the existing required run via
  `idd-rerun-advisory-convergence --apply` when the comment is
  IDD-originated (reply-identity stamp, disposition prefix, or an
  operational marker) — it never asserts `ready` itself.
- Added an overridable `runner` `workflow_dispatch` input (default
  `ubuntu-slim`, falling back to the `CI_RUNNER_LABEL` repository
  variable) to `idd-advisory-convergence.yml`, replacing the
  hardcoded `runs-on: ubuntu-latest`, per roadmap #162's
  authoring-time decision. The precedence expression is adopted from
  `idd-skill`'s `idd-template/.github/workflows/idd-advisory-convergence.yml`
  copy at the `v0.7.0` tag, not its dogfooded root copy (which
  hardcodes `ubuntu-slim` with no override input at all) — confirmed
  by fetching both files directly from `kurone-kito/idd-skill`.
- Follow-up self-review fix: gave the companion workflow's job the
  same `CI_RUNNER_LABEL` fallback (`${{ vars.CI_RUNNER_LABEL || 'ubuntu-slim' }}`)
  so a self-hosted-runner requirement (e.g. GHES) covers it too, not
  only the required job. It has no `runner` input of its own since it
  never triggers via `workflow_dispatch`.
- Updated `docs/idd-policy.md` and `docs/customization.md`'s
  advisory-convergence guidance, which previously described the
  required workflow as listening for `pull_request_review_comment` —
  now stale — to describe the new companion workflow and runner
  override instead. `.github/instructions/idd-ci.instructions.md`'s
  "self-heals on ... a review-thread reply" sentence was deliberately
  left as-is: it is byte-identical to `idd-skill`'s own still-current
  `v0.7.0` wording for that file, and rewriting it locally would
  diverge from the pinned instructions template on a point upstream
  itself hasn't revised.

The job id `idd-advisory-convergence` (the required-status-check
context / check-run name that `idd-rerun-advisory-convergence` and
the external-check-waiver mechanism hardcode as an exact-string match)
is unchanged — no `name:` override was added to either job.

## Isolation-safety reasoning

- Distinct `name:` on the companion (`IDD advisory-convergence
  comment refresh` vs. `IDD advisory-convergence gate`) → distinct
  `${{ github.workflow }}` → distinct concurrency `group:` string,
  even for the same PR number, so a companion run can never queue
  into or cancel the required job's own concurrency slot.
- Distinct job id (`refresh-if-idd-originated` vs.
  `idd-advisory-convergence`) → distinct check-run context, so the
  companion's own run can never post to, overwrite, or be confused
  with the required check-run the branch-protection rollup reads.
- The only cross-workflow interaction is the companion's conditional
  `idd-rerun-advisory-convergence --apply` call, which reruns the
  *existing* required-job run for the current HEAD SHA via the
  Actions API — the same sanctioned recovery mechanic already
  documented in `idd-ci.instructions.md`'s "Rerun mechanics" section,
  not a new mutation path.
- Net effect: an ordinary human review-thread reply triggers the
  companion, classifies as not-IDD-originated, and takes no action at
  all on the required check. Only an IDD-originated reply reruns the
  existing required run; the companion never asserts `ready` itself.

## Verification

- `pnpm run lint`, `pnpm run build`, and `pnpm run test` all pass
  locally (91/91 tests).
- `actionlint` reports zero issues on both changed/new workflow files
  (this repository has no workflow YAML linter wired into `pnpm run
  lint`, so this was a manual check).
- Live-read of this repository's ruleset confirms `idd-advisory-convergence`
  remains the sole required status check on `main`; the companion is
  not registered as required
  (`gh api repos/kurone-kito/builder-config/rulesets/20674407`).
- Locally verified `review-comment-origin.mjs`'s classifier against
  this repository's actual `markerPrefix` (`builder-config`): an
  `LGTM`-style body classifies `iddOriginated: false`; a
  disposition-prefixed body, a `<!-- builder-config-review-reply
  -->`-stamped body, and an operational-marker body each classify
  `true`.
- Confirmed `review-comment-origin.mjs` has **no** `idd-review-comment-origin`
  bin/CLI facade in the vendored `@kurone-kito/idd-skill@0.7.0`
  package at this repository's pin (absent from the package's own
  `bin` field and this repository's `package.json` `idd:*` script
  map) — it ships only as a plain vendored script, invoked here via
  `node node_modules/@kurone-kito/idd-skill/scripts/review-comment-origin.mjs`
  rather than `pnpm exec idd-*`. `idd-rerun-advisory-convergence`
  (used in the companion's second step) does have a bin facade
  already wired in this repository's `package.json`.
- Two independent critique passes (plan-stage and diff-stage, run as
  separate subagents per this repository's Claude Code critique-pass
  convention) reviewed this change; both found only the one
  `CI_RUNNER_LABEL` gap above, already fixed in the follow-up commit.
- **Live-fire criterion**: this PR's own required check exercises the
  runner-override half of the split live (it now runs on
  `ubuntu-slim` via the new default). The comment-trigger half needs
  an actual review-thread reply on this PR to exercise; will update
  this section with the observed result, mirroring #65's
  partial-live-fire precedent if only one half reproduces naturally
  before merge.

## Recommended follow-up issues

None. `mergePolicy`, `reviewPolicy`, and the CHANGELOG
release-time-batch rule are unchanged, per this issue's explicit
scope.

Closes #163
