### PR TITLE
docs(idd): reconcile core instruction/lite files against v0.7.0 named gaps

### DIFF
--- a/.claude/skills/issue-authoring/references/contract.md
+++ b/.claude/skills/issue-authoring/references/contract.md
@@ -653,10 +653,7 @@ A drafted issue's human-readable prose sections — `## Background` (or
 - The literal `match-source` matches the operator's live conversational
   language during an interactive/hearing issue-authoring session.
 - An absent field defaults to English, codifying today's actual
-  emergent behavior.
-
-See `docs/customization.md`'s Authoring Language section for the full
-field definition.
+  emergent behavior (fail-safe default).
 
 **Marker/footer carve-out**: this never changes any HTML-comment
 marker's machine-parsed format, nor any visible-line mirror whose exact

--- a/.claude/skills/issue-authoring/references/contract.md
+++ b/.claude/skills/issue-authoring/references/contract.md
@@ -386,6 +386,100 @@ Ask these checks:
    taxonomy. An owner/CODEOWNERS marker or a referenced tracking issue may
    also serve, but the code-comment convention is the recommended default.
    Do not hard-code any single consumer's divergence-tracking mechanism.
+4. When an issue drafts a **template resync or reimport** (pulling a
+   newer `idd-template/` revision into a repository that already
+   adopted IDD), consult the **upstream target ref's** copy of
+   `docs/customization.md`'s "Documentation lint compatibility"
+   section (added 2026-08-05, commit `6ceaa6dd`) before treating
+   `.markdownlint.yml` / `.markdownlint-cli2.yaml` / `.cspell.config.yml`
+   as unchanged. `docs/customization.md` is itself part of the
+   imported core file set, so it resolves in an installed or adopter
+   context once present — but an adopter whose prior import predates
+   that commit has no such section in their own local copy yet, which
+   is exactly the named gap to document in the resync issue, not a
+   documentation-consultation failure. Either the target ref's
+   `docs/customization.md` section or, from a source checkout of
+   `idd-skill` itself, `idd-template/ONBOARDING.md`'s "Re-importing"
+   section, documents the same named gap: an adopter's own rule
+   customizations for these files need a by-hand merge into the new
+   import rather than an assumed carry-forward, and
+   `idd-onboard.mjs --import` reports a `blockedOverwrites` finding
+   instead of silently keeping a same-named local file as-is, unless
+   the import used `--force`, which still writes the file and reports
+   it in the verdict JSON (`plan` as an `overwrite` entry,
+   `filesChanged`, and `written`) but omits it from
+   `blockedOverwrites` so the import is not blocked (observed
+   2026-08-12/13 on an
+   adopter repository, `setup.ubuntu`, kurone-kito/idd-skill#2012).
+5. When drafting a resync issue's Background, run a mechanical
+   placeholder diff against the **upstream `idd-skill` source
+   repository's** `idd-template/` trees at the two relevant refs —
+   never a tree inside the target/adopter repository itself, which
+   retains no local `idd-template/` directory of its own once IDD is
+   imported.
+   - **Baseline ref.** Use the exact tag or commit SHA actually
+     imported at the adopter's prior onboarding when it is explicitly
+     recorded (for example in the original onboarding PR/commit
+     message) or when the operator can confirm it directly. Do not
+     infer it from the adopter's current file content: neither a diff
+     against the import commit nor a reverse- or forward-substitution
+     content-match against a candidate upstream tree reliably pins a
+     single ref — onboarding substitutes placeholder values and
+     permits legitimate post-substitution edits, an import commit's
+     diff itself only records the already-transformed adopter
+     snapshot, and more than one upstream commit can plausibly yield
+     the same imported subset. When no explicit record or operator
+     confirmation is available, report the baseline as
+     unresolved/ambiguous in the resync issue itself rather than
+     guessing one from content alone. Do not construct `v<iddVersion>`
+     (`.github/idd/config.json`) as the baseline without this check:
+     `iddVersion` is only a coarse signal and can be stale, an adopter
+     still on `0.1.0` has no matching tag at all (`CHANGELOG.md`
+     records that `0.1.0` predates the tag discipline), and an adopter
+     who pinned a raw
+     commit SHA at import time instead of a tag may have no
+     `v<iddVersion>` tag matching what they actually imported either.
+   - **Target ref.** The new release/ref the resync targets.
+   - **Scope.** Intersect both trees with the Step 2 "File list" core
+     file set as it reads **at the target ref**
+     (`idd-template/ONBOARDING.md`'s generated file-list block) plus
+     whichever optional profile artifacts the adopter selected, not
+     the complete `idd-template/` tree — a file such as
+     `idd-template/ONBOARDING.md` itself is never copied into an
+     adopter, so reporting it as changed is noise. Use the target
+     ref's manifest, not the baseline ref's: a file the target release
+     newly added to the core or a selected profile is exactly the kind
+     of change a resync issue must report, and the baseline ref's own
+     manifest predates it.
+   - **Token filter.** Compare each ref's own placeholder table in
+     effect at that ref, not today's list applied to both — a
+     placeholder added or removed between the two refs is itself
+     exactly the kind of token-identity change this check exists to
+     report, and reusing one ref's list for the other's tree would
+     hide that change. At a ref from commit `e55ccd9c` (2026-05-12)
+     onward, that table is Onboarding Reference — Placeholder Values'
+     "Final placeholder meanings" table
+     (`docs/onboarding/placeholders.md`). An older ref has no such
+     file — the placeholders were documented directly inside
+     `idd-template/ONBOARDING.md`'s own "Step 1C — Collect placeholder
+     values" section instead; use that section's list as the
+     allowlist for a baseline ref that old. Never match every
+     `{{...}}`-shaped span unfiltered either way — an unrestricted
+     match also catches ordinary GitHub Actions expressions such as
+     `${{ github.token }}` in an imported workflow file.
+   - **Excluded paths.** Skip `docs/onboarding/placeholders.md`,
+     `docs/customization.md`, and `docs/onboarding/policy-decisions.md`
+     — these deliberately keep `{{...}}` tokens literal to document
+     the placeholder syntax itself, so diffing them misidentifies
+     literal documentation as an outstanding substitution.
+
+   Compare the actual token identities per changed file, not only the
+   aggregate occurrence count: a same-count one-for-one placeholder
+   swap changes what an adopter must substitute without changing the
+   count. Name any file whose placeholder tokens changed, rather than
+   asserting a file needs no placeholder substitution as an unverified
+   default (observed 2026-08-12/13 on an adopter repository,
+   `setup.ubuntu`, kurone-kito/idd-skill#2012).
 
 ## Dependency minimization
 
@@ -545,6 +639,32 @@ Validation expectations:
   marker; a score of `1` also carries `status:blocked-by-human`
 - passes the `audit-authored-issue` mechanical pre-publish gate for the
   `child` shape (see [Mechanical pre-publish gate](#mechanical-pre-publish-gate))
+
+## Drafted issue prose language
+
+A drafted issue's human-readable prose sections — `## Background` (or
+`## Goal`/`## Why this matters`), `## Proposed change`,
+`## Acceptance criteria`, and the roadmap shape's `## Tracks` /
+`## Success criteria` — follow the target repository's resolved
+`authoringLanguage` value from `.github/idd/config.json`:
+
+- A fixed BCP-47-shaped tag (for example `en`, `ja`, `fr`) makes the
+  drafted prose use that language.
+- The literal `match-source` matches the operator's live conversational
+  language during an interactive/hearing issue-authoring session.
+- An absent field defaults to English, codifying today's actual
+  emergent behavior.
+
+See `docs/customization.md`'s Authoring Language section for the full
+field definition.
+
+**Marker/footer carve-out**: this never changes any HTML-comment
+marker's machine-parsed format, nor any visible-line mirror whose exact
+wording a mechanical regex parses. Concretely, the autopilot-suitability
+and effort footers' visible lines (`_Autopilot suitability: N / 5 ...`
+/ `_Effort: S | M | L ...`) must stay in their exact canonical English
+wording regardless of `authoringLanguage`, since `audit-authored-issue`
+matches them against a fixed English-phrase regex.
 
 ## A4.5 Suitability Gate Alignment
 

--- a/.github/instructions/idd-ci.instructions.md
+++ b/.github/instructions/idd-ci.instructions.md
@@ -21,8 +21,12 @@ node scripts/ci-wait-policy.mjs
 <profile-selected-ci-wait-policy-command>
 ```
 
-Append `--rerun-count <count>` when the caller needs the deterministic
-rerun-budget decision. Resolve
+Prefer `--run-id <run-id>` (derives the rerun-budget count from the
+run's own `run_attempt` field, mirroring
+`rerun-advisory-convergence.mjs`) when a run ID is available; append
+`--rerun-count <count>` directly for the same deterministic
+rerun-budget decision otherwise — this manual form remains valid and
+is not being replaced. Resolve
 `<profile-selected-ci-wait-policy-command>` from
 `docs/idd-helper-scripts.md`. Do not hardcode
 `node scripts/ci-wait-policy.mjs` for profiles that don't vendor

--- a/.github/instructions/idd-claim.instructions.md
+++ b/.github/instructions/idd-claim.instructions.md
@@ -48,6 +48,22 @@ gate-enable, actor-policy, approval-signal, and fail-closed rules as
 A bare organization `MEMBER` association never counts as approval;
 neither do issue body text, a generated plan, or operator attention.
 
+**Self-authorization fallback when the permission read is unavailable
+at claim time** (`kurone-kito/idd-skill#2148`): when the collaborator
+permission API read for this check is itself unavailable (a `503`, an
+empty response, or otherwise unreadable) — not merely a non-approving
+result — the issue-author self-authorization signal alone may
+substitute the issue's own live `author_association` instead of
+failing closed: `OWNER` always self-authorizes; `MEMBER`
+self-authorizes under both `owners-and-maintainers-only` and
+`all-write-permission-actors`. This narrower fallback covers only the
+issue-author signal at this A5(a) claim-time check — the
+approval-comment and ready-label signals still fail closed on an
+unreadable permission read. `idd-discover.instructions.md`'s own A3.5
+gate is unchanged by this fallback and keeps its unconditional
+fail-closed rule for the earlier discovery-time check; hardening A3.5
+to match is a recommended follow-up, not covered here.
+
 - If approval is missing for a roadmap/default discovery run, return to
   Discover using the same selection mode that produced this target so
   A3.5 can continue with the next eligible startable issue or the
@@ -451,6 +467,31 @@ confirm it still equals the carried nonce. A different winner (e.g. a
 later forced-handoff collision the orchestrator never saw) means the
 worker is no longer the winning activation — treat that the same as any
 other lost claim.
+
+**State the worker role explicitly when the delegate inherits full
+context.** Some delegation mechanisms give the worker the
+orchestrator's own complete conversation context instead of a clean
+slate limited to the brief. There, the worker can carry over the
+orchestrator's own framing — mistaking itself for the session that
+launched several workers and is waiting on their replies — instead of
+recognizing the brief reassigns it to a single-issue worker role. The
+delegation brief must state explicitly that the delegate is the sole
+worker for the named issue, that no peer workers exist for it to
+coordinate with or wait on, and that it must perform the implementation
+work itself rather than re-delegate or wait for a reply
+(`kurone-kito/idd-skill#2179`).
+
+**Restate the CI/advisory-wait topology-safety condition.** The
+delegation brief must also carry — verbatim or by direct reference —
+the CI/advisory-wait topology-safety condition from [idd-ci.instructions.md's
+Wake-up discipline](idd-ci.instructions.md#wake-up-discipline), the same
+requirement already stated for this delegation pattern in
+[docs/idd-workflow.md's Orchestrator fan-out
+variant](../../docs/idd-workflow.md#orchestrator-fan-out-variant). Without
+it, a worker can end its turn on a Monitor-style or backgrounded wait
+assuming an unconfirmed notification resumes it — under a
+supervisor/worker topology, only the supervisor is notified, so the
+worker's own turn stalls indefinitely (`kurone-kito/idd-skill#2210`).
 
 ### Hide displaced claim chain on takeover
 

--- a/.github/instructions/idd-claim.instructions.md
+++ b/.github/instructions/idd-claim.instructions.md
@@ -43,7 +43,9 @@ issue itself.
 **(a) Issue-author approval gate** — Re-evaluate the repository-wide
 issue-author approval rule immediately before claim, using the same
 gate-enable, actor-policy, approval-signal, and fail-closed rules as
-**A3.5** of `idd-discover.instructions.md`.
+**A3.5** of `idd-discover.instructions.md`, except for the
+self-authorization fallback below, which applies only at this A5(a)
+claim-time check.
 
 A bare organization `MEMBER` association never counts as approval;
 neither do issue body text, a generated plan, or operator attention.

--- a/.github/instructions/idd-pr-submit.instructions.md
+++ b/.github/instructions/idd-pr-submit.instructions.md
@@ -217,12 +217,12 @@ body. Do not add a parallel "worker-lite authoring" contract.
 
 The PR body's prose sections above (summary, background/rationale,
 follow-up notes) follow the resolved `authoringLanguage` value from
-`.github/idd/config.json`: a fixed language tag when configured, the
-claimed issue's own body language when the value is `match-source`
-(this file's unattended-execution case, with no live operator), or
-English when the field is absent. See the
-[Authoring Language](../../docs/customization.md#authoring-language)
-section for the full field definition.
+`.github/idd/config.json`: a fixed BCP-47-shaped language tag (for
+example `en`, `ja`, `fr`) when configured, the claimed issue's own body
+language when the value is the literal `match-source` (this file's
+unattended-execution case, with no live operator to match a live
+conversational language against), or English when the field is absent
+(fail-safe default, matching today's emergent behavior).
 
 This never changes a machine-parsed marker or an exact-regex-matched
 visible line, which always stays in its canonical form regardless of

--- a/.github/instructions/idd-pr-submit.instructions.md
+++ b/.github/instructions/idd-pr-submit.instructions.md
@@ -206,6 +206,33 @@ reviewers that are not auto-assigned by GitHub, request them explicitly:
 gh pr edit {pr-number} --add-reviewer {reviewer-login}
 ```
 
+**Do not create follow-up issues directly.** An executing IDD session
+must never call `gh issue create` (or the REST issues API) itself.
+Recommended follow-ups stay in the PR body's own prose above. If a
+follow-up is important enough to file in-repo now, invoke the
+`issue-authoring` skill (its Stage 1 hold) instead of improvising a
+body. Do not add a parallel "worker-lite authoring" contract.
+
+### PR body language
+
+The PR body's prose sections above (summary, background/rationale,
+follow-up notes) follow the resolved `authoringLanguage` value from
+`.github/idd/config.json`: a fixed language tag when configured, the
+claimed issue's own body language when the value is `match-source`
+(this file's unattended-execution case, with no live operator), or
+English when the field is absent. See the
+[Authoring Language](../../docs/customization.md#authoring-language)
+section for the full field definition.
+
+This never changes a machine-parsed marker or an exact-regex-matched
+visible line, which always stays in its canonical form regardless of
+`authoringLanguage`. Concretely here, the closing keyword line below
+(`Closes #N` and its variants) must keep its exact English keyword
+form: GitHub's own closing-keyword parser and this file's D3.5
+verification regex both match only the English keyword forms
+(`close[sd]?`/`fix(e[sd])?`/`resolve[sd]?`), so translating that line
+would silently break auto-close detection.
+
 ### D3.5 — Verify closing keyword detection
 
 After PR creation and before D4, confirm GitHub recognized the

--- a/.github/instructions/idd-review-triage.instructions.md
+++ b/.github/instructions/idd-review-triage.instructions.md
@@ -84,7 +84,14 @@ maintainer confirmation for an unprivileged PATH A actor: confirmed →
 `Accept` and act; **false on the live evidence** → disposition it
 `Rejected` and cite the contradicting evidence (the code as read, the
 real run conclusion, file contents, or artifact) — a verified-false
-claim is a reasoned rejection, not an action item.
+claim is a reasoned rejection, not an action item (scoped to this
+verification only — not E4/E5's Low-severity/no-action `Rejected`
+routes); **inconclusive** (neither confirmed nor contradicted — the
+needed check has no route here, not merely low confidence) → for an
+actor-permission-capped, reviewer-feedback PATH A item, route it
+through the CODEOWNER/required-reviewer AMD hold (E6) instead of
+`Rejected`, using E6's marker (a critique-pass finding stays under
+the unchanged cap above).
 
 **Resolved-thread duplicate pre-check (PATH B, before verification).**
 Before verification above, check whether a new PATH B item — a review
@@ -150,15 +157,19 @@ PATH A — Accepted items:
   reviewer feedback is replied to after the fix work in
   `idd-review-fix.instructions.md`.
 
-PATH A — Rejected reviewer feedback:
+PATH A — Rejected/inconclusive reviewer feedback:
 
-For each Rejected PATH A item whose source is reviewer feedback:
+For each Rejected or inconclusive (E5) PATH A item whose source is
+reviewer feedback:
 
-- Reply using the format: `**Rejected** — {reason}`
-- **Exception**: if the source is a CODEOWNER or required reviewer, do
-  not reject unilaterally. Reply using the format:
-  `**Awaiting maintainer decision** — {your reasoning}` and wait for the
-  maintainer's response.
+- Reply using the format: `**Rejected** — {reason}` — unless the
+  Exception below applies.
+- **Exception**: if the source is a CODEOWNER or required reviewer, or
+  the item is E5's inconclusive outcome, do not reject unilaterally.
+  Reply using the format:
+  `**Awaiting maintainer decision** — {your reasoning}` (name the
+  unavailable check when inconclusive) and wait for the maintainer's
+  response.
 - After posting your reply, **immediately resolve the thread** — except
   for `**Awaiting maintainer decision**`. When helper runtime is enabled,
   the profile-selected resolve-review-thread command (`--pr <number>
@@ -194,13 +205,12 @@ For each Rejected PATH A item whose source is reviewer feedback:
   in a future E1 pass.
 - **When the maintainer eventually responds** (their response surfaces
   in a future E1 pass as an unresolved thread or new reply):
-  - If the maintainer **agrees with your rejection**: reply summarizing
+  - If the maintainer **agrees no action is needed**: reply summarizing
     the agreed decision (e.g.,
     `**Rejection confirmed by maintainer** — {summary}`) and resolve the
     thread.
-  - If the maintainer **disagrees**: move the item from Rejected to
-    Accepted and proceed through the fix flow. Resolve the thread after
-    fixing.
+  - If the maintainer **disagrees**: move the item to Accepted and
+    proceed through the fix flow. Resolve the thread after fixing.
   - If the maintainer's response arrived in a separate PR comment or
     review rather than in the original thread: mirror the decision onto
     the original thread and resolve the thread. Also **reply to the
@@ -232,7 +242,10 @@ For each Rejected PATH A item whose source is reviewer feedback:
   - If the reviewer responds and disagrees: move the item to Accepted
     and proceed through the fix flow.
   - If the reviewer responds (either way): restart from E1.
-- If you decide "Reject now but should do eventually": open a new issue.
+- If you decide "Reject now but should do eventually": open a new issue
+  following `idd-pr-submit.instructions.md` D3's follow-up-issue rule —
+  never call `gh issue create` (or the REST issues API) directly; use
+  the `issue-authoring` skill.
   The new issue's body must include a `Refs #NNN` line on its own
   line (not narrative prose) back to the originating issue — use
   `Refs` specifically and reference the issue, never the PR: a
@@ -248,7 +261,7 @@ Use these prefixes so that disposition is always unambiguous:
 - PATH B acceptance marker (only for a _completed_ review of the current
   HEAD): `**Accepted** — {what the advisory comment confirmed}`
 - Ordinary rejection: `**Rejected** — {reason}`
-- CODEOWNER / required reviewer exception:
+- CODEOWNER / required reviewer, or inconclusive (E5), exception:
   `**Awaiting maintainer decision** — {reasoning}`
 
 Two requirements make the F2/F3 disposition-evidence gate recognize an
@@ -354,13 +367,14 @@ review state.
 Before leaving triage, verify every ReviewItems_snapshot item has the
 evidence required by its path:
 
-- Every PATH A item has a recorded classification and an Accept or
-  Reject decision. Every Accepted item cites its "Verify before accept"
-  evidence, or the maintainer confirmation reply when actor-permission
-  capped.
-- Every Rejected PATH A item whose source is reviewer feedback has the
-  required rejection or `**Awaiting maintainer decision**` reply posted,
-  and any non-AMD thread resolution is complete.
+- Every PATH A item has a recorded classification and an Accept,
+  Reject, or AMD decision (including E5 inconclusive). Every Accepted
+  item cites its "Verify before accept" evidence, or the maintainer
+  confirmation reply when actor-permission capped.
+- Every Rejected or inconclusive PATH A item whose source is reviewer
+  feedback has the required rejection or
+  `**Awaiting maintainer decision**` reply posted, and any non-AMD
+  thread resolution is complete.
 - Every PATH B item has a posted `**Accepted**` or `**Rejected**`
   marker. Review threads are resolved immediately after the marker.
 - Only Accepted PATH A items remain candidates for

--- a/.github/instructions/idd-work.instructions.md
+++ b/.github/instructions/idd-work.instructions.md
@@ -301,7 +301,11 @@ implementation is correct, whether the issue's requirements are
 satisfied, whether adequate test coverage exists, and whether any other
 problems exist. See `idd-overview-appendix.instructions.md` for per-agent
 implementation. The distributed defaults for the C-phase skip and loop
-guards are listed in `docs/policy-constants.md`.
+guards are listed in `docs/policy-constants.md`. A repository may
+optionally configure `critiqueLoop.delegate` — a `command` run against
+the branch's current diff — to point this step at a different reviewer
+instead of the per-agent mechanism described here; absent, invalid, or
+failing, C1 runs the per-agent mechanism unchanged.
 
 **Objective diff validation floor**: neither C2 nor C4 below may skip to
 `idd-pr-submit.instructions.md` unless **fix-validate** — the same

--- a/.github/instructions/lite/idd-ci-lite.instructions.md
+++ b/.github/instructions/lite/idd-ci-lite.instructions.md
@@ -37,8 +37,9 @@ CI-polling instructions instead of this file.
 ## Helper-first canonical path
 
 1. Resolve policy: `node scripts/ci-wait-policy.mjs` (append
-   `--rerun-count <count>` for the rerun-budget decision). Resolve the
-   package-manager / ephemeral-npx equivalent from
+   `--run-id <run-id>` — preferred, derives the rerun budget from
+   `run_attempt` — or `--rerun-count <count>` as a manual fallback).
+   Resolve the package-manager / ephemeral-npx equivalent from
    `docs/idd-helper-scripts.md`. This helper already resolves
    `ciWait.*` from `.github/idd/config.json` and emits the final
    `runningTimeout` / `generationTimeout` / `rerunPolicy` values

--- a/.github/instructions/lite/idd-pr-submit-lite.instructions.md
+++ b/.github/instructions/lite/idd-pr-submit-lite.instructions.md
@@ -208,7 +208,14 @@ loop instead of returning to this D1 rebase path.
    background/rationale only when it materially affects review. Ground
    any background/rationale only in the issue discussion, commits,
    diff, or explicit operator instructions — omit rather than
-   speculate.
+   speculate. The prose sections follow the resolved `authoringLanguage` value
+   from `.github/idd/config.json` (fixed tag, the claimed issue's own body
+   language for `match-source`, or English if absent — see
+   [Authoring Language](../../../docs/customization.md#authoring-language));
+   this never changes any machine-parsed marker or exact-regex-matched visible
+   line, which stays canonical regardless — concretely, the closing keyword line
+   stays canonical English: GitHub's parser and D3.5's verification regex below
+   match only the English keyword forms.
 4. **Closing keyword**: write a plain-text line such as `Closes #N` for
    the claimed issue number, on its own line. GitHub recognizes these
    keyword forms (case-insensitive): `close`, `closes`, `closed`, `fix`,
@@ -226,6 +233,10 @@ loop instead of returning to this D1 rebase path.
 7. If CODEOWNERS or expected reviewers are not auto-assigned, request
    them explicitly: `gh pr edit {pr-number} --add-reviewer
    {reviewer-login}`.
+8. **Do not create follow-up issues directly** — never call `gh issue
+   create` (or the REST issues API) yourself. Recommended follow-ups
+   stay in the PR body prose above; if one is important enough to file
+   now, invoke the `issue-authoring` skill instead.
 
 ### D3.5 — Verify closing keyword detection
 
@@ -364,11 +375,11 @@ than the run it supersedes. Once both have completed, the later
    external target rather than an Actions run; or its entry has `type:
    "check-run"` but an empty `url` (the upstream `detailsUrl` was
    itself absent). Otherwise resolve the rerun
-   decision from the
-   run's own history: `gh run view <run-id-from-url> --json attempt` —
-   GitHub's `attempt` starts at `1` for a never-rerun run, so pass
-   `attempt - 1` as `<count>` to `node scripts/ci-wait-policy.mjs
-   --rerun-count <count>`, never this wait's own memory. If it allows
+   decision directly from the run's own live state:
+   `node scripts/ci-wait-policy.mjs --run-id <run-id-from-url>`
+   (`--owner`/`--repo` when targeting a different repository) — this
+   derives the budget mechanically from the run's own `run_attempt`
+   field, never this wait's own memory. If it allows
    a rerun, rerun that check once as a **whole-run rerun, not
    `--failed`** (`gh run rerun <run-id-from-url>`) — a stalled check
    has no failed jobs to selectively rerun, only a run that never

--- a/.github/instructions/lite/idd-pr-submit-lite.instructions.md
+++ b/.github/instructions/lite/idd-pr-submit-lite.instructions.md
@@ -209,13 +209,14 @@ loop instead of returning to this D1 rebase path.
    any background/rationale only in the issue discussion, commits,
    diff, or explicit operator instructions — omit rather than
    speculate. The prose sections follow the resolved `authoringLanguage` value
-   from `.github/idd/config.json` (fixed tag, the claimed issue's own body
-   language for `match-source`, or English if absent — see
-   [Authoring Language](../../../docs/customization.md#authoring-language));
-   this never changes any machine-parsed marker or exact-regex-matched visible
-   line, which stays canonical regardless — concretely, the closing keyword line
-   stays canonical English: GitHub's parser and D3.5's verification regex below
-   match only the English keyword forms.
+   from `.github/idd/config.json` (a fixed BCP-47-shaped tag, the claimed
+   issue's own body language for the literal `match-source`, or English if
+   absent — see `idd-pr-submit.instructions.md`'s "PR body language" section
+   for the full field definition); this never changes any machine-parsed
+   marker or exact-regex-matched visible line, which stays canonical
+   regardless — concretely, the closing keyword line stays canonical
+   English: GitHub's parser and D3.5's verification regex below match only
+   the English keyword forms.
 4. **Closing keyword**: write a plain-text line such as `Closes #N` for
    the claimed issue number, on its own line. GitHub recognizes these
    keyword forms (case-insensitive): `close`, `closes`, `closed`, `fix`,

--- a/.github/skills/issue-authoring/references/contract.md
+++ b/.github/skills/issue-authoring/references/contract.md
@@ -653,10 +653,7 @@ A drafted issue's human-readable prose sections — `## Background` (or
 - The literal `match-source` matches the operator's live conversational
   language during an interactive/hearing issue-authoring session.
 - An absent field defaults to English, codifying today's actual
-  emergent behavior.
-
-See `docs/customization.md`'s Authoring Language section for the full
-field definition.
+  emergent behavior (fail-safe default).
 
 **Marker/footer carve-out**: this never changes any HTML-comment
 marker's machine-parsed format, nor any visible-line mirror whose exact

--- a/.github/skills/issue-authoring/references/contract.md
+++ b/.github/skills/issue-authoring/references/contract.md
@@ -386,6 +386,100 @@ Ask these checks:
    taxonomy. An owner/CODEOWNERS marker or a referenced tracking issue may
    also serve, but the code-comment convention is the recommended default.
    Do not hard-code any single consumer's divergence-tracking mechanism.
+4. When an issue drafts a **template resync or reimport** (pulling a
+   newer `idd-template/` revision into a repository that already
+   adopted IDD), consult the **upstream target ref's** copy of
+   `docs/customization.md`'s "Documentation lint compatibility"
+   section (added 2026-08-05, commit `6ceaa6dd`) before treating
+   `.markdownlint.yml` / `.markdownlint-cli2.yaml` / `.cspell.config.yml`
+   as unchanged. `docs/customization.md` is itself part of the
+   imported core file set, so it resolves in an installed or adopter
+   context once present — but an adopter whose prior import predates
+   that commit has no such section in their own local copy yet, which
+   is exactly the named gap to document in the resync issue, not a
+   documentation-consultation failure. Either the target ref's
+   `docs/customization.md` section or, from a source checkout of
+   `idd-skill` itself, `idd-template/ONBOARDING.md`'s "Re-importing"
+   section, documents the same named gap: an adopter's own rule
+   customizations for these files need a by-hand merge into the new
+   import rather than an assumed carry-forward, and
+   `idd-onboard.mjs --import` reports a `blockedOverwrites` finding
+   instead of silently keeping a same-named local file as-is, unless
+   the import used `--force`, which still writes the file and reports
+   it in the verdict JSON (`plan` as an `overwrite` entry,
+   `filesChanged`, and `written`) but omits it from
+   `blockedOverwrites` so the import is not blocked (observed
+   2026-08-12/13 on an
+   adopter repository, `setup.ubuntu`, kurone-kito/idd-skill#2012).
+5. When drafting a resync issue's Background, run a mechanical
+   placeholder diff against the **upstream `idd-skill` source
+   repository's** `idd-template/` trees at the two relevant refs —
+   never a tree inside the target/adopter repository itself, which
+   retains no local `idd-template/` directory of its own once IDD is
+   imported.
+   - **Baseline ref.** Use the exact tag or commit SHA actually
+     imported at the adopter's prior onboarding when it is explicitly
+     recorded (for example in the original onboarding PR/commit
+     message) or when the operator can confirm it directly. Do not
+     infer it from the adopter's current file content: neither a diff
+     against the import commit nor a reverse- or forward-substitution
+     content-match against a candidate upstream tree reliably pins a
+     single ref — onboarding substitutes placeholder values and
+     permits legitimate post-substitution edits, an import commit's
+     diff itself only records the already-transformed adopter
+     snapshot, and more than one upstream commit can plausibly yield
+     the same imported subset. When no explicit record or operator
+     confirmation is available, report the baseline as
+     unresolved/ambiguous in the resync issue itself rather than
+     guessing one from content alone. Do not construct `v<iddVersion>`
+     (`.github/idd/config.json`) as the baseline without this check:
+     `iddVersion` is only a coarse signal and can be stale, an adopter
+     still on `0.1.0` has no matching tag at all (`CHANGELOG.md`
+     records that `0.1.0` predates the tag discipline), and an adopter
+     who pinned a raw
+     commit SHA at import time instead of a tag may have no
+     `v<iddVersion>` tag matching what they actually imported either.
+   - **Target ref.** The new release/ref the resync targets.
+   - **Scope.** Intersect both trees with the Step 2 "File list" core
+     file set as it reads **at the target ref**
+     (`idd-template/ONBOARDING.md`'s generated file-list block) plus
+     whichever optional profile artifacts the adopter selected, not
+     the complete `idd-template/` tree — a file such as
+     `idd-template/ONBOARDING.md` itself is never copied into an
+     adopter, so reporting it as changed is noise. Use the target
+     ref's manifest, not the baseline ref's: a file the target release
+     newly added to the core or a selected profile is exactly the kind
+     of change a resync issue must report, and the baseline ref's own
+     manifest predates it.
+   - **Token filter.** Compare each ref's own placeholder table in
+     effect at that ref, not today's list applied to both — a
+     placeholder added or removed between the two refs is itself
+     exactly the kind of token-identity change this check exists to
+     report, and reusing one ref's list for the other's tree would
+     hide that change. At a ref from commit `e55ccd9c` (2026-05-12)
+     onward, that table is Onboarding Reference — Placeholder Values'
+     "Final placeholder meanings" table
+     (`docs/onboarding/placeholders.md`). An older ref has no such
+     file — the placeholders were documented directly inside
+     `idd-template/ONBOARDING.md`'s own "Step 1C — Collect placeholder
+     values" section instead; use that section's list as the
+     allowlist for a baseline ref that old. Never match every
+     `{{...}}`-shaped span unfiltered either way — an unrestricted
+     match also catches ordinary GitHub Actions expressions such as
+     `${{ github.token }}` in an imported workflow file.
+   - **Excluded paths.** Skip `docs/onboarding/placeholders.md`,
+     `docs/customization.md`, and `docs/onboarding/policy-decisions.md`
+     — these deliberately keep `{{...}}` tokens literal to document
+     the placeholder syntax itself, so diffing them misidentifies
+     literal documentation as an outstanding substitution.
+
+   Compare the actual token identities per changed file, not only the
+   aggregate occurrence count: a same-count one-for-one placeholder
+   swap changes what an adopter must substitute without changing the
+   count. Name any file whose placeholder tokens changed, rather than
+   asserting a file needs no placeholder substitution as an unverified
+   default (observed 2026-08-12/13 on an adopter repository,
+   `setup.ubuntu`, kurone-kito/idd-skill#2012).
 
 ## Dependency minimization
 
@@ -545,6 +639,32 @@ Validation expectations:
   marker; a score of `1` also carries `status:blocked-by-human`
 - passes the `audit-authored-issue` mechanical pre-publish gate for the
   `child` shape (see [Mechanical pre-publish gate](#mechanical-pre-publish-gate))
+
+## Drafted issue prose language
+
+A drafted issue's human-readable prose sections — `## Background` (or
+`## Goal`/`## Why this matters`), `## Proposed change`,
+`## Acceptance criteria`, and the roadmap shape's `## Tracks` /
+`## Success criteria` — follow the target repository's resolved
+`authoringLanguage` value from `.github/idd/config.json`:
+
+- A fixed BCP-47-shaped tag (for example `en`, `ja`, `fr`) makes the
+  drafted prose use that language.
+- The literal `match-source` matches the operator's live conversational
+  language during an interactive/hearing issue-authoring session.
+- An absent field defaults to English, codifying today's actual
+  emergent behavior.
+
+See `docs/customization.md`'s Authoring Language section for the full
+field definition.
+
+**Marker/footer carve-out**: this never changes any HTML-comment
+marker's machine-parsed format, nor any visible-line mirror whose exact
+wording a mechanical regex parses. Concretely, the autopilot-suitability
+and effort footers' visible lines (`_Autopilot suitability: N / 5 ...`
+/ `_Effort: S | M | L ...`) must stay in their exact canonical English
+wording regardless of `authoringLanguage`, since `audit-authored-issue`
+matches them against a fixed English-phrase regex.
 
 ## A4.5 Suitability Gate Alignment
 

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -687,6 +687,15 @@ The adopted helper boundaries are intentionally narrow:
 - `ci-wait-policy.mjs` is read-only, resolves `ciWait.*` defaults from
   `.github/idd/config.json`, and can evaluate whether the current rerun
   count still permits an automatic rerun
+- `--run-id <run-id>` (with `--owner`/`--repo`, defaulting to the local
+  checkout's own repository) derives that rerun count mechanically from
+  the live run's `run_attempt` field via `gh api
+  repos/{owner}/{repo}/actions/runs/{run-id}`, the same pattern
+  `rerun-advisory-convergence.mjs` already uses for its own budget check
+  — preferred over passing `--rerun-count` by hand, since `run_attempt`
+  is live GitHub state and cross-session-safe by construction; `--rerun-count`
+  keeps working unchanged when `--run-id` is omitted, and serves as an
+  explicit fallback when the `--run-id` lookup fails
 - it does not poll CI, rerun workflows, or replace the CI decision
   table; it only reduces config-copy variance when callers need the
   shared CI wait defaults
@@ -1343,13 +1352,32 @@ to post it is the consuming track's job.
     idd-ci-wait-policy
   ```
 
-- Optional rerun-budget evaluation: append
-  `--rerun-count <count>` to the selected command
+- Optional rerun-budget evaluation, preferred mechanical form: append
+  `--run-id <run-id>` (with `--owner`/`--repo`, defaulting to the local
+  checkout's own repository when omitted) to derive `rerunCount =
+  run_attempt - 1` from the live Actions run (`gh api
+  repos/{owner}/{repo}/actions/runs/{run-id}`), the same `run_attempt`
+  pattern `rerun-advisory-convergence.mjs` already uses for its own
+  budget check
+- Optional rerun-budget evaluation, manual/offline form: append
+  `--rerun-count <count>` to the selected command instead — this keeps
+  working unchanged when `--run-id` is omitted, and serves as the
+  explicit fallback if `--run-id`'s live lookup fails (network/
+  permission error, or a missing/non-numeric `run_attempt` in the
+  fetched payload). `--run-id` takes precedence over `--rerun-count`
+  only when both are given and the live lookup succeeds; with no
+  `--rerun-count` fallback, a failed `--run-id` lookup exits non-zero
+  with a clear reason instead of silently resolving to a `0` rerun count
 - Stable fields consumed by instructions or helpers:
   `policy.runningTimeout`, `policy.runningTimeoutMs`,
   `policy.generationTimeout`, `policy.generationTimeoutMs`,
   `policy.rerunPolicy`, and optional `rerunDecision.action` /
-  `rerunDecision.reason`
+  `rerunDecision.reason`. When `--run-id` was given: `rerunCountSource`
+  (`"run-id"` or `"rerun-count"`, reporting which source ultimately
+  supplied `rerunDecision`'s `rerunCount`), `runAttempt` (the fetched
+  run's raw `run_attempt`, only present on a successful live lookup),
+  and `runIdLookupError` (only present when the live lookup failed but a
+  `--rerun-count` fallback was available)
 - it remains read-only; the command does not poll CI, rerun workflows,
   or post any GitHub comment
 

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -653,10 +653,7 @@ A drafted issue's human-readable prose sections — `## Background` (or
 - The literal `match-source` matches the operator's live conversational
   language during an interactive/hearing issue-authoring session.
 - An absent field defaults to English, codifying today's actual
-  emergent behavior.
-
-See `docs/customization.md`'s Authoring Language section for the full
-field definition.
+  emergent behavior (fail-safe default).
 
 **Marker/footer carve-out**: this never changes any HTML-comment
 marker's machine-parsed format, nor any visible-line mirror whose exact

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -386,6 +386,100 @@ Ask these checks:
    taxonomy. An owner/CODEOWNERS marker or a referenced tracking issue may
    also serve, but the code-comment convention is the recommended default.
    Do not hard-code any single consumer's divergence-tracking mechanism.
+4. When an issue drafts a **template resync or reimport** (pulling a
+   newer `idd-template/` revision into a repository that already
+   adopted IDD), consult the **upstream target ref's** copy of
+   `docs/customization.md`'s "Documentation lint compatibility"
+   section (added 2026-08-05, commit `6ceaa6dd`) before treating
+   `.markdownlint.yml` / `.markdownlint-cli2.yaml` / `.cspell.config.yml`
+   as unchanged. `docs/customization.md` is itself part of the
+   imported core file set, so it resolves in an installed or adopter
+   context once present — but an adopter whose prior import predates
+   that commit has no such section in their own local copy yet, which
+   is exactly the named gap to document in the resync issue, not a
+   documentation-consultation failure. Either the target ref's
+   `docs/customization.md` section or, from a source checkout of
+   `idd-skill` itself, `idd-template/ONBOARDING.md`'s "Re-importing"
+   section, documents the same named gap: an adopter's own rule
+   customizations for these files need a by-hand merge into the new
+   import rather than an assumed carry-forward, and
+   `idd-onboard.mjs --import` reports a `blockedOverwrites` finding
+   instead of silently keeping a same-named local file as-is, unless
+   the import used `--force`, which still writes the file and reports
+   it in the verdict JSON (`plan` as an `overwrite` entry,
+   `filesChanged`, and `written`) but omits it from
+   `blockedOverwrites` so the import is not blocked (observed
+   2026-08-12/13 on an
+   adopter repository, `setup.ubuntu`, kurone-kito/idd-skill#2012).
+5. When drafting a resync issue's Background, run a mechanical
+   placeholder diff against the **upstream `idd-skill` source
+   repository's** `idd-template/` trees at the two relevant refs —
+   never a tree inside the target/adopter repository itself, which
+   retains no local `idd-template/` directory of its own once IDD is
+   imported.
+   - **Baseline ref.** Use the exact tag or commit SHA actually
+     imported at the adopter's prior onboarding when it is explicitly
+     recorded (for example in the original onboarding PR/commit
+     message) or when the operator can confirm it directly. Do not
+     infer it from the adopter's current file content: neither a diff
+     against the import commit nor a reverse- or forward-substitution
+     content-match against a candidate upstream tree reliably pins a
+     single ref — onboarding substitutes placeholder values and
+     permits legitimate post-substitution edits, an import commit's
+     diff itself only records the already-transformed adopter
+     snapshot, and more than one upstream commit can plausibly yield
+     the same imported subset. When no explicit record or operator
+     confirmation is available, report the baseline as
+     unresolved/ambiguous in the resync issue itself rather than
+     guessing one from content alone. Do not construct `v<iddVersion>`
+     (`.github/idd/config.json`) as the baseline without this check:
+     `iddVersion` is only a coarse signal and can be stale, an adopter
+     still on `0.1.0` has no matching tag at all (`CHANGELOG.md`
+     records that `0.1.0` predates the tag discipline), and an adopter
+     who pinned a raw
+     commit SHA at import time instead of a tag may have no
+     `v<iddVersion>` tag matching what they actually imported either.
+   - **Target ref.** The new release/ref the resync targets.
+   - **Scope.** Intersect both trees with the Step 2 "File list" core
+     file set as it reads **at the target ref**
+     (`idd-template/ONBOARDING.md`'s generated file-list block) plus
+     whichever optional profile artifacts the adopter selected, not
+     the complete `idd-template/` tree — a file such as
+     `idd-template/ONBOARDING.md` itself is never copied into an
+     adopter, so reporting it as changed is noise. Use the target
+     ref's manifest, not the baseline ref's: a file the target release
+     newly added to the core or a selected profile is exactly the kind
+     of change a resync issue must report, and the baseline ref's own
+     manifest predates it.
+   - **Token filter.** Compare each ref's own placeholder table in
+     effect at that ref, not today's list applied to both — a
+     placeholder added or removed between the two refs is itself
+     exactly the kind of token-identity change this check exists to
+     report, and reusing one ref's list for the other's tree would
+     hide that change. At a ref from commit `e55ccd9c` (2026-05-12)
+     onward, that table is Onboarding Reference — Placeholder Values'
+     "Final placeholder meanings" table
+     (`docs/onboarding/placeholders.md`). An older ref has no such
+     file — the placeholders were documented directly inside
+     `idd-template/ONBOARDING.md`'s own "Step 1C — Collect placeholder
+     values" section instead; use that section's list as the
+     allowlist for a baseline ref that old. Never match every
+     `{{...}}`-shaped span unfiltered either way — an unrestricted
+     match also catches ordinary GitHub Actions expressions such as
+     `${{ github.token }}` in an imported workflow file.
+   - **Excluded paths.** Skip `docs/onboarding/placeholders.md`,
+     `docs/customization.md`, and `docs/onboarding/policy-decisions.md`
+     — these deliberately keep `{{...}}` tokens literal to document
+     the placeholder syntax itself, so diffing them misidentifies
+     literal documentation as an outstanding substitution.
+
+   Compare the actual token identities per changed file, not only the
+   aggregate occurrence count: a same-count one-for-one placeholder
+   swap changes what an adopter must substitute without changing the
+   count. Name any file whose placeholder tokens changed, rather than
+   asserting a file needs no placeholder substitution as an unverified
+   default (observed 2026-08-12/13 on an adopter repository,
+   `setup.ubuntu`, kurone-kito/idd-skill#2012).
 
 ## Dependency minimization
 
@@ -545,6 +639,32 @@ Validation expectations:
   marker; a score of `1` also carries `status:blocked-by-human`
 - passes the `audit-authored-issue` mechanical pre-publish gate for the
   `child` shape (see [Mechanical pre-publish gate](#mechanical-pre-publish-gate))
+
+## Drafted issue prose language
+
+A drafted issue's human-readable prose sections — `## Background` (or
+`## Goal`/`## Why this matters`), `## Proposed change`,
+`## Acceptance criteria`, and the roadmap shape's `## Tracks` /
+`## Success criteria` — follow the target repository's resolved
+`authoringLanguage` value from `.github/idd/config.json`:
+
+- A fixed BCP-47-shaped tag (for example `en`, `ja`, `fr`) makes the
+  drafted prose use that language.
+- The literal `match-source` matches the operator's live conversational
+  language during an interactive/hearing issue-authoring session.
+- An absent field defaults to English, codifying today's actual
+  emergent behavior.
+
+See `docs/customization.md`'s Authoring Language section for the full
+field definition.
+
+**Marker/footer carve-out**: this never changes any HTML-comment
+marker's machine-parsed format, nor any visible-line mirror whose exact
+wording a mechanical regex parses. Concretely, the autopilot-suitability
+and effort footers' visible lines (`_Autopilot suitability: N / 5 ...`
+/ `_Effort: S | M | L ...`) must stay in their exact canonical English
+wording regardless of `authoringLanguage`, since `audit-authored-issue`
+matches them against a fixed English-phrase regex.
 
 ## A4.5 Suitability Gate Alignment
 


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/builder-config/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/builder-config/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/builder-config/blob/main/.github/CONTRIBUTING.zh.md
-->

## Summary

Reconciles this repository's core IDD instruction/lite files and the
issue-authoring skill bundle against the **named gaps** enumerated in
#164, diffed against `kurone-kito/idd-skill` at the pin
`f51a8bb73a47452eff5799e8a27251b660ba4ae0` (tag `v0.7.0`). This is a
named-gap reconciliation, not a file-for-file overwrite — only the
enumerated behaviors are adopted; unrelated upstream changes in the
same files (a commit-message closing-keyword scanner, harness-native
worktree tooling, `review-ack` markers, `{{PROJECT_MARKER_PREFIX}}`
templating, etc.) are intentionally left untouched, preserving this
repository's local divergences (`package-manager` helper-runtime
profile, monorepo/`pnpm --filter` references, repository-specific
prose).

- `idd-review-triage.instructions.md`: adds the E5 "inconclusive"
  review outcome (CODEOWNER/AMD-hold routed) and the mandate that a
  reject-but-should-fix follow-up goes through the `issue-authoring`
  skill instead of a raw `gh issue create`.
- `idd-claim.instructions.md`: adds the orchestrator/fan-out
  delegation-brief hardening (sole-worker-role statement,
  CI/advisory-wait topology-safety restatement) and an A5(a)
  claim-time `author_association` (`OWNER`/`MEMBER`) fallback for when
  the collaborator-permission API read is itself unavailable.
- `idd-pr-submit.instructions.md` (+ its lite counterpart): adds the
  `authoringLanguage` PR-body-prose behavior description.
- `idd-work.instructions.md`: adds a description of the optional
  `critiqueLoop.delegate` field, framed as inert when absent/invalid —
  this repository is not adopting it.
- `idd-ci.instructions.md`, `docs/idd-helper-scripts.md` (+
  `idd-ci-lite.instructions.md`): document the new `--run-id` input as
  the preferred way to derive the CI rerun-budget count (via
  `run_attempt`), alongside the existing `--rerun-count <count>` flag.
- `skills/issue-authoring/references/contract.md` and its two mirrors
  (`.claude/skills/...`, `.github/skills/...`, kept byte-identical):
  adds the "Drafted issue prose language" section (`authoringLanguage`)
  and the template-resync-issue-drafting guidance (upstream-source-tree
  placeholder diffing, baseline-ref resolution rules,
  `blockedOverwrites`/`--force` nuance).

`idd-review-fix-lite.instructions.md` was named in the issue's
Background list but is left unchanged — its only upstream delta versus
this repository's copy is an unrelated commitlint merge-message fix,
not a counterpart of any of the five named gaps.

## Deviation from the issue's literal wording

The issue's own paraphrase of the `idd-claim.instructions.md` gap said
"falls back ... when the collaborator-permission API returns a 5xx."
The actual upstream trigger (transcribed from the pinned clone,
`kurone-kito/idd-skill#2148`) is broader — "unavailable (a `503`, an
empty response, or otherwise unreadable)" — and scoped only to the
issue-author self-authorization signal, not the approval-comment or
ready-label signals. The shipped text uses the broader, correctly
scoped upstream wording.

`docs/customization.md#authoring-language` was going to be a
forward-reference to sibling issue #165, but a self-review pass found
#165's own plan never touches `docs/customization.md` (it targets
`docs/idd-policy.md` and `docs/onboarding/policy-decisions.md`
instead) — so that anchor would never resolve. The field definition is
inlined directly in `idd-pr-submit.instructions.md` and
`contract.md` instead, with the lite file and the two `contract.md`
mirrors pointing at those in-repo descriptions rather than the
nonexistent section.

## Recommended follow-up

- `idd-discover.instructions.md`'s A3.5 gate keeps its unconditional
  fail-closed rule; the new A5(a) self-authorization fallback added
  here deliberately does not touch it (that file isn't in #164's
  named-gap list). Hardening A3.5 to match upstream's own
  discovery-time fallback is a good follow-up, tracked separately from
  this PR.
- Codex review flagged that `idd-claim-lite.instructions.md` and
  `idd-work-lite.instructions.md` do not mirror the new A5(a)
  self-authorization fallback and `critiqueLoop.delegate` description
  respectively, despite each lite file's own "same semantics as the
  standard phase" promise. Verified this gap already exists in
  upstream `kurone-kito/idd-skill` v0.7.0's own lite files (diffed
  against the pinned clone: header-comment-only diff, no content
  difference) — neither lite file is in #164's named-gap list, and
  both mismatches are behaviorally inert in this repository today
  (`idd-claim-lite`'s unconditional fail-closed is the conservative
  direction; this repository configures no `critiqueLoop.delegate`).
  Rejected locally rather than adding local-only content upstream
  doesn't have (see the resolved review threads); this is an
  upstream-first fix candidate for `kurone-kito/idd-skill` itself,
  tracked here as a recommendation rather than filed as a new issue
  mid-run.

## Verification

- `pnpm exec idd-doctor`: passes, no stale-import warning (only the
  pre-existing, unrelated release-tag-drift warning).
- `pnpm run lint`, `pnpm run build`, `pnpm run test`: all pass (91
  tests, 22 files).
- `git diff --stat main..HEAD`: touches exactly the 11 named files,
  nothing else.
- The three `contract.md` mirrors are confirmed byte-identical
  (`diff -q`) after every edit.
- Two independent critique passes ran during B2 (plan-level) and C1
  (diff-level); all findings from both were resolved before this PR
  (see the issue's B2 plan comment for the full trail).
- Copilot reviewed all 11 changed files with no comments. Codex
  (`chatgpt-codex-connector[bot]`) raised 3 findings; all verified
  against live evidence (shipped upstream source/tests, and a direct
  diff against the pinned upstream clone) and rejected with reasoning
  on each resolved thread — see the "Recommended follow-up" section
  above for the two upstream-first candidates among them.

Closes #164

