### PR TITLE
feat(idd): adopt match-source authoringLanguage policy key

### DIFF
--- a/.github/idd/config.json
+++ b/.github/idd/config.json
@@ -5,6 +5,7 @@
   "mergePolicy": "fully_autonomous_merge",
   "reviewPolicy": "copilot-advisory",
   "threadResolutionPolicy": "fast-agent-resolve",
+  "authoringLanguage": "match-source",
   "claimTiming": {
     "staleAge": "PT24H",
     "heartbeatInterval": "PT12H"

--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -218,6 +218,30 @@ reviews every PR in this repository.
 
 - **`issueAuthoring.maxClarificationRounds`**: `3`
 
+## Authoring Language
+
+**Policy**: `authoringLanguage` = `match-source` (decided at the roadmap
+authoring hearing on 2026-08-20, issue #165 — later than this file's
+original 2026-07-14/2026-08-01 policy batch above).
+
+This repository's IDD sessions run in whatever language the operator
+uses live at the time (frequently Japanese), while `CLAUDE.md` requires
+code comments and documentation to stay in English. A fixed language tag
+would conflict with that convention in one direction or the other: a
+fixed `ja` tag would fight any session actually run in English, and a
+fixed `en` tag would ignore the operator's live language choice. The
+literal `match-source` value avoids both failure modes by following
+whichever language a given session is actually conducted in — the live
+conversational language during an interactive/hearing session
+(issue-authoring, onboarding) and the implemented issue's own body
+language during unattended execution with no live operator (for example
+PR-submit), per
+[`idd-pr-submit.instructions.md`'s PR body language rule](../.github/instructions/idd-pr-submit.instructions.md#pr-body-language)
+(updated by issue #164 / PR #172 to describe how the field is read).
+This never changes a machine-parsed marker or an exact-regex-matched
+visible line, which always stays in its canonical English form
+regardless of this setting.
+
 ## IDD Labels
 
 Distributed defaults: `roadmap`, `status:blocked-by-human`,


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/builder-config/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/builder-config/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/builder-config/blob/main/.github/CONTRIBUTING.zh.md
-->

## Summary

Adopts idd-skill v0.7.0's optional `authoringLanguage` policy field with
the `match-source` value:

- Adds `"authoringLanguage": "match-source"` to `.github/idd/config.json`,
  placed after `threadResolutionPolicy` and before `claimTiming` to match
  `policy.schema.json`'s own declared property order.
- Records the decision and its `match-source`-over-fixed-tag rationale in
  a new `## Authoring Language` section in `docs/idd-policy.md`.

Closes #165

## Rationale

This repository's IDD sessions run in whatever language the operator
uses live at the time (frequently Japanese), while `CLAUDE.md` requires
code comments and documentation to stay in English. A fixed language tag
would conflict with that convention in one direction or the other — a
fixed `ja` tag would fight any session actually run in English, and a
fixed `en` tag would ignore the operator's live language choice. The
literal `match-source` value avoids both failure modes: it follows the
live conversational language during an interactive/hearing session
(issue-authoring, onboarding) and the implemented issue's own body
language during unattended execution with no live operator (for example
PR-submit), per `idd-pr-submit.instructions.md`'s PR body language rule
(already updated by #164 / PR #172 to describe how the field is read).
Decided at the roadmap authoring hearing on 2026-08-20 (issue #165's own
body), and is the last child of roadmap #162.

## Verification

- `docs/onboarding/policy-decisions.md` was checked for a companion
  summary/template section covering comparable keys. Neither the repo's
  own copy nor the pinned upstream v0.7.0 template copy
  (`node_modules/@kurone-kito/idd-skill/idd-template/docs/onboarding/policy-decisions.md`)
  has an `authoringLanguage` entry — in the per-key decision sections or
  in the "Recording the selected policies" fill-in-the-blank template —
  so this is an upstream gap, not something dropped from this repo's own
  import. No edit made there.
- `pnpm exec idd-doctor` passes with `.github/idd/config.json validates
  against policy.schema.json` still `PASS` (the schema field is
  `type: string`, pattern `^(match-source|[a-z]{2,3}(-[A-Za-z0-9]{2,8})*)$`,
  not required), and the one pre-existing `WARN` (release-tag drift) is
  unrelated to this change.
- `pnpm run lint`, `pnpm run build`, and `pnpm run test` all pass
  (91/91 tests).

## Follow-up issues

None.
