### PR TITLE
docs(idd-policy): record critique-loop delegate decline decision

### DIFF
--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -38,6 +38,9 @@ profile.
 **Profile**: distributed defaults from `docs/policy-constants.md` — no
 repository override.
 
+See [Critique-Loop Delegate](#critique-loop-delegate) below for the
+separate `critiqueLoop.delegate` decline decision.
+
 ## Claim Timing
 
 - **claim-stale-age**: 24 h (distributed default)
@@ -241,6 +244,29 @@ PR-submit), per
 This never changes a machine-parsed marker or an exact-regex-matched
 visible line, which always stays in its canonical English form
 regardless of this setting.
+
+## Critique-Loop Delegate
+
+**Decision**: the optional `critiqueLoop.delegate` policy field was
+considered and **declined**, at the same roadmap-authoring hearing on
+2026-08-20 that decided `authoringLanguage` above — both decisions are
+recorded together in roadmap #162's own issue body, though
+`authoringLanguage` was implemented via its own tracked child issue
+(#165), while this decline was never assigned an execution issue until
+now (#174):
+
+> `critiqueLoop.delegate`: declined. It only has effect once a concrete
+> external reviewer command exists to delegate to, which this
+> repository does not have; revisit as a fresh issue if/when one is
+> adopted.
+
+As a direct result, `.github/idd/config.json` intentionally carries no
+`critiqueLoop.delegate` entry — a decline means no config entry to add,
+not an explicit disabled value, so this file's own "keep both in sync"
+rule at the top has nothing to mirror here.
+`.github/instructions/idd-work.instructions.md` C1 already documents
+the fallback behavior for this field: absent, invalid, or a failing
+delegate leaves C1 running the per-agent critique mechanism unchanged.
 
 ## IDD Labels
 


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/builder-config/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/builder-config/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/builder-config/blob/main/.github/CONTRIBUTING.zh.md
-->

## Summary

Roadmap #162's 2026-08-20 authoring hearing considered and declined
adopting the optional `critiqueLoop.delegate` policy field (no
concrete external reviewer command exists yet to delegate to), but
that decision only existed as prose inside #162's own issue body. This
PR transcribes it into `docs/idd-policy.md`, this repository's actual
policy-of-record file, next to the `## Authoring Language` section
decided at the same hearing, and cross-references it from the existing
`## Critique-Loop Profile` section.

- Adds a new `## Critique-Loop Delegate` section with the decision, a
  verbatim blockquote of #162's own rationale text, an explicit note
  that `.github/idd/config.json` intentionally carries no
  `critiqueLoop.delegate` entry as a result, and a pointer to
  `idd-work.instructions.md` C1's already-documented
  inert-when-absent fallback behavior.
- Adds a one-line cross-reference under `## Critique-Loop Profile`
  pointing to the new section.
- `docs/onboarding/policy-decisions.md` is left unchanged: it is a
  generic upstream-mirrored onboarding-confirmation reference with no
  comparable declined/optional-key summary-table entry for any field
  (matching what issue #165 already found for `authoringLanguage`).

Documentation-only: no schema, `.github/idd/config.json`, or
instruction-file change.

Closes #174

## Background

None beyond the summary above; this is a straightforward
decision-transcription gap-fill found during roadmap #162's own
completion audit.
