### PR TITLE
docs(idd): document shared rerun-once budget as intentional (#171)

### DIFF
--- a/.github/instructions/idd-ci.instructions.md
+++ b/.github/instructions/idd-ci.instructions.md
@@ -261,6 +261,26 @@ before the next.
 rerun this SAME existing run via the mechanic above — never
 `workflow_dispatch`.
 
+**Shared rerun-once budget with comment-triggered refreshes (`#171`)**:
+`rerun-advisory-convergence.mjs`'s per-instance rerun eligibility (keyed
+by GitHub's own `run_attempt` on that check-run instance) is the SAME
+`ciWait.rerunPolicy` budget this section's own CI-wait infra-retry uses
+— it is also spent by the `idd-advisory-convergence-comment.yml`
+companion workflow (added by issue `#163`; see `docs/idd-policy.md`'s
+`idd-advisory-convergence` workflow section) when it reruns a check
+instance in response to an IDD-originated PR comment. If one caller
+already rerun a given instance once, a later IDD-originated comment
+wanting to refresh that same still-stuck instance is silently withheld
+as `rerun-budget-exhausted` rather than granted an independent budget.
+This is accepted, intentional, bounded-recovery-by-design behavior, not
+a bug — it mirrors `ciWait.rerunPolicy`'s own escalate-after-one-rerun
+philosophy rather than letting reruns multiply across trigger sources.
+**Self-healing recovery**: if a same-HEAD comment-triggered refresh is
+withheld this way, the next push, a fresh bot review, or a maintainer's
+manual rerun creates a new run instance (its own fresh `run_attempt`)
+with its own budget, clearing the stale-red state with no further
+action needed.
+
 ## Interpretation
 
 <!-- dprint-ignore-start -->

--- a/.github/instructions/idd-ci.instructions.md
+++ b/.github/instructions/idd-ci.instructions.md
@@ -268,10 +268,11 @@ by GitHub's own `run_attempt` on that check-run instance) is the SAME
 — it is also spent by the `idd-advisory-convergence-comment.yml`
 companion workflow (added by issue `#163`; see `docs/idd-policy.md`'s
 `idd-advisory-convergence` workflow section) when it reruns a check
-instance in response to an IDD-originated PR comment. If one caller has
-already rerun a given instance once, a later IDD-originated comment
-wanting to refresh that same still-stuck instance is silently withheld
-as `rerun-budget-exhausted` rather than granted an independent budget.
+instance in response to an IDD-originated review-thread comment. If one
+caller has already rerun a given instance once, a later IDD-originated
+comment wanting to refresh that same still-stuck instance is silently
+withheld as `rerun-budget-exhausted` rather than granted an independent
+budget.
 This is accepted, intentional, bounded-recovery-by-design behavior, not
 a bug — it mirrors `ciWait.rerunPolicy`'s own escalate-after-one-rerun
 philosophy rather than letting reruns multiply across trigger sources.

--- a/.github/instructions/idd-ci.instructions.md
+++ b/.github/instructions/idd-ci.instructions.md
@@ -280,14 +280,15 @@ philosophy rather than letting reruns multiply across trigger sources.
 withheld this way, the next push creates a new run instance (its own
 fresh `run_attempt`) with its own budget, clearing the stale-red state
 with no further action needed. A maintainer's manual rerun (`gh run
-rerun <run-id>` or the Actions UI) also clears it directly, since a
-human isn't bound by this automation's own once-only budget — but it
-reruns the same run and increments that run's `run_attempt`, so this
-tooling's own automated rerun still treats that instance as
-budget-exhausted afterward. A fresh bot review is not a reliable
-recovery path on its own: its own bot-triggered run can re-enter
-`action_required` (see the bot-gated cause above) instead of clearing
-the rollup.
+rerun <run-id>` or the Actions UI) can also force that same run to
+execute again — a human isn't bound by this automation's own
+once-only budget, though this only forces a fresh execution, not a
+guaranteed pass. It reruns the same run and increments that run's
+`run_attempt`, so this tooling's own automated rerun still treats
+that instance as budget-exhausted afterward. A fresh bot review is
+not a reliable recovery path on its own: its own bot-triggered run
+can re-enter `action_required` (see the bot-gated cause above)
+instead of clearing the rollup.
 
 ## Interpretation
 

--- a/.github/instructions/idd-ci.instructions.md
+++ b/.github/instructions/idd-ci.instructions.md
@@ -268,7 +268,7 @@ by GitHub's own `run_attempt` on that check-run instance) is the SAME
 — it is also spent by the `idd-advisory-convergence-comment.yml`
 companion workflow (added by issue `#163`; see `docs/idd-policy.md`'s
 `idd-advisory-convergence` workflow section) when it reruns a check
-instance in response to an IDD-originated PR comment. If one caller
+instance in response to an IDD-originated PR comment. If one caller has
 already rerun a given instance once, a later IDD-originated comment
 wanting to refresh that same still-stuck instance is silently withheld
 as `rerun-budget-exhausted` rather than granted an independent budget.

--- a/.github/instructions/idd-ci.instructions.md
+++ b/.github/instructions/idd-ci.instructions.md
@@ -277,10 +277,17 @@ This is accepted, intentional, bounded-recovery-by-design behavior, not
 a bug — it mirrors `ciWait.rerunPolicy`'s own escalate-after-one-rerun
 philosophy rather than letting reruns multiply across trigger sources.
 **Self-healing recovery**: if a same-HEAD comment-triggered refresh is
-withheld this way, the next push, a fresh bot review, or a maintainer's
-manual rerun creates a new run instance (its own fresh `run_attempt`)
-with its own budget, clearing the stale-red state with no further
-action needed.
+withheld this way, the next push creates a new run instance (its own
+fresh `run_attempt`) with its own budget, clearing the stale-red state
+with no further action needed. A maintainer's manual rerun (`gh run
+rerun <run-id>` or the Actions UI) also clears it directly, since a
+human isn't bound by this automation's own once-only budget — but it
+reruns the same run and increments that run's `run_attempt`, so this
+tooling's own automated rerun still treats that instance as
+budget-exhausted afterward. A fresh bot review is not a reliable
+recovery path on its own: its own bot-triggered run can re-enter
+`action_required` (see the bot-gated cause above) instead of clearing
+the rollup.
 
 ## Interpretation
 

--- a/.github/instructions/lite/idd-ci-lite.instructions.md
+++ b/.github/instructions/lite/idd-ci-lite.instructions.md
@@ -150,6 +150,11 @@ CI-polling shared helper file), never this one. Read
 - Helper-first diagnosis (read-only): `node
   scripts/rerun-advisory-convergence.mjs --pr <n>`. Resolve the
   package-manager equivalent from `docs/idd-helper-scripts.md`.
+- Shared rerun-once budget (`#171`): a check instance's `ciWait.rerunPolicy`
+  budget is shared between this section's own rerun and a
+  comment-triggered refresh from `idd-advisory-convergence-comment.yml`
+  — intentional, not a bug; a withheld refresh self-heals on the next
+  push, fresh bot review, or manual rerun.
 
 ## Wake-up discipline
 

--- a/.github/instructions/lite/idd-ci-lite.instructions.md
+++ b/.github/instructions/lite/idd-ci-lite.instructions.md
@@ -154,7 +154,10 @@ CI-polling shared helper file), never this one. Read
   budget is shared between this section's own rerun and a
   comment-triggered refresh from `idd-advisory-convergence-comment.yml`
   — intentional, not a bug; a withheld refresh self-heals on the next
-  push, fresh bot review, or manual rerun.
+  push (a fresh run instance with its own budget) or a maintainer's
+  manual rerun (clears the check directly, though it reruns the same
+  run rather than granting a fresh budget). A fresh bot review is not
+  reliable here — it can itself re-enter `action_required`.
 
 ## Wake-up discipline
 

--- a/.github/instructions/lite/idd-ci-lite.instructions.md
+++ b/.github/instructions/lite/idd-ci-lite.instructions.md
@@ -155,8 +155,8 @@ CI-polling shared helper file), never this one. Read
   comment-triggered refresh from `idd-advisory-convergence-comment.yml`
   — intentional, not a bug; a withheld refresh self-heals on the next
   push (a fresh run instance with its own budget) or a maintainer's
-  manual rerun (clears the check directly, though it reruns the same
-  run rather than granting a fresh budget). A fresh bot review is not
+  manual rerun (forces the same run to execute again, not a guaranteed
+  pass, without granting a fresh budget). A fresh bot review is not
   reliable here — it can itself re-enter `action_required`.
 
 ## Wake-up discipline


### PR DESCRIPTION
## Summary

Documents `rerun-advisory-convergence.mjs`'s shared rerun-once budget
residual (`ciWait.rerunPolicy`, keyed by GitHub's `run_attempt`) as
accepted, intentional, bounded-recovery-by-design behavior, per the
maintainer's recorded Decision: Option B on issue #171 — rather than
proposing a behavioral change upstream against `kurone-kito/idd-skill`.

- `.github/instructions/idd-ci.instructions.md`: new paragraph in the
  Rerun mechanics section (after the Terminal-waiver recheck note,
  before the Interpretation table) covering: (1) the shared-budget
  mechanism between D4/E15's own CI-wait infra-retry and the
  `idd-advisory-convergence-comment.yml` companion workflow (issue
  #163) when it reruns a check instance for an IDD-originated
  review-thread comment; (2) that this mirrors `ciWait.rerunPolicy`'s
  own escalate-after-one-rerun philosophy and is not a bug; (3) the
  self-healing recovery path (next push, fresh bot review, or
  maintainer manual rerun creates a fresh `run_attempt` with its own
  budget).
- `.github/instructions/lite/idd-ci-lite.instructions.md`: an
  equivalently condensed one-line note in its own Rerun mechanics
  section, since that file already documents `ciWait.rerunPolicy`.

No changes to `rerun-advisory-convergence.mjs`, any vendored script, or
any workflow file — this is a documentation-only change recording a
decision already made on the issue thread.

## Background/rationale

Issue #171 traced a real but unreproduced residual from PR #170's
live-fire exercise: if a check-run instance's rerun-once budget is
already spent (by either D4/E15's own CI-wait or an earlier
comment-triggered refresh), a later IDD-originated review-thread
comment wanting to refresh that same still-stuck instance is silently
withheld as `rerun-budget-exhausted` until an unrelated new trigger
creates a fresh instance. The maintainer's Decision: Option B comment
on the issue judged this as self-healing (a transient stale-red state,
not a permanently stuck PR), plausibly intentional by design (mirrors
`ciWait.rerunPolicy`'s own philosophy), and not reproduced as a live
failure — so the right-sized response is documenting the residual
locally with its own recovery guidance, not an upstream ask.

Closes #171
