### PR TITLE
docs(idd): note comment-workflow queue-eviction residual (#177)

### DIFF
--- a/.github/instructions/idd-ci.instructions.md
+++ b/.github/instructions/idd-ci.instructions.md
@@ -291,29 +291,33 @@ can re-enter `action_required` (see the bot-gated cause above)
 instead of clearing the rollup.
 
 **Queue-eviction of a queued comment-triggered refresh (`#177`)**:
-`idd-advisory-convergence-comment.yml`'s own concurrency group
-(`cancel-in-progress: false`, `group: ${{ github.workflow }}-${{
-github.event.pull_request.number }}`) queues at most one pending run
-per PR — distinct from the required `idd-advisory-convergence.yml`
-workflow's own `cancel-in-progress: true` group, which cancels rather
-than queues. If an IDD-originated comment's triggered run is queued
-behind an already-executing run, and a later ORDINARY (non-IDD)
-comment arrives before the first finishes, GitHub Actions' own
-queue-depth-1 behavior evicts the queued IDD-originated run in favor
-of the newer one. The classify step (`review-comment-origin.mjs`) only
-inspects the current triggering comment's own body, not full PR state,
-so the evicting run correctly — from its own narrow per-event view —
-classifies itself non-IDD-originated and takes no action; the evicted
-refresh is lost until another trigger fires.
+`idd-advisory-convergence-comment.yml`'s own concurrency group uses
+`cancel-in-progress: false`, grouped by PR number, which queues at
+most one pending run per PR — distinct from the required
+`idd-advisory-convergence.yml` workflow's own `cancel-in-progress:
+true` group, which cancels rather than queues. If an IDD-originated
+comment's triggered run is queued behind an already-executing run, and
+a later ORDINARY (non-IDD) comment arrives before the first finishes,
+GitHub Actions' own queue-depth-1 behavior evicts the queued
+IDD-originated run in favor of the newer one. The classify step
+(`review-comment-origin.mjs`) only inspects the current triggering
+comment's own body, not full PR state, so the evicting run correctly —
+from its own narrow per-event view — classifies itself
+non-IDD-originated and takes no action; the evicted refresh is lost
+until another trigger fires.
 This is accepted as a residual of the workflow's own narrow, per-event
 classify-step design, not a defect to silently patch — no fix was
 found that doesn't trade away that design principle (evaluating full
 current PR state instead of just the triggering comment would be a
 real architectural change with its own tradeoffs, not an
 obviously-better alternative). **Self-healing recovery**: a subsequent
-push, a fresh bot review, or a maintainer's manual rerun (`gh run
-rerun <run-id>` or the Actions UI) creates a fresh trigger and clears
-the stale state.
+push or a maintainer's manual rerun (`gh run rerun <run-id>` or the
+Actions UI) creates a fresh trigger and clears the stale state. A
+fresh bot review is not a reliable recovery path here either — the
+same bot-gated `action_required` risk noted above (a
+`pull_request_review`-triggered run for the required workflow can
+re-enter `action_required` instead of completing) applies to this
+residual too.
 
 ## Interpretation
 

--- a/.github/instructions/idd-ci.instructions.md
+++ b/.github/instructions/idd-ci.instructions.md
@@ -290,6 +290,31 @@ not a reliable recovery path on its own: its own bot-triggered run
 can re-enter `action_required` (see the bot-gated cause above)
 instead of clearing the rollup.
 
+**Queue-eviction of a queued comment-triggered refresh (`#177`)**:
+`idd-advisory-convergence-comment.yml`'s own concurrency group
+(`cancel-in-progress: false`, `group: ${{ github.workflow }}-${{
+github.event.pull_request.number }}`) queues at most one pending run
+per PR — distinct from the required `idd-advisory-convergence.yml`
+workflow's own `cancel-in-progress: true` group, which cancels rather
+than queues. If an IDD-originated comment's triggered run is queued
+behind an already-executing run, and a later ORDINARY (non-IDD)
+comment arrives before the first finishes, GitHub Actions' own
+queue-depth-1 behavior evicts the queued IDD-originated run in favor
+of the newer one. The classify step (`review-comment-origin.mjs`) only
+inspects the current triggering comment's own body, not full PR state,
+so the evicting run correctly — from its own narrow per-event view —
+classifies itself non-IDD-originated and takes no action; the evicted
+refresh is lost until another trigger fires.
+This is accepted as a residual of the workflow's own narrow, per-event
+classify-step design, not a defect to silently patch — no fix was
+found that doesn't trade away that design principle (evaluating full
+current PR state instead of just the triggering comment would be a
+real architectural change with its own tradeoffs, not an
+obviously-better alternative). **Self-healing recovery**: a subsequent
+push, a fresh bot review, or a maintainer's manual rerun (`gh run
+rerun <run-id>` or the Actions UI) creates a fresh trigger and clears
+the stale state.
+
 ## Interpretation
 
 <!-- dprint-ignore-start -->

--- a/.github/instructions/idd-ci.instructions.md
+++ b/.github/instructions/idd-ci.instructions.md
@@ -317,14 +317,16 @@ architectural change, and even a narrower per-event alternative — keying
 the concurrency group by comment id instead of PR number — would trade
 away the shared per-PR serialization that prevents concurrent reruns of
 the same required-check run; neither is an obviously-better alternative.
-**Self-healing recovery**: a subsequent push, or a maintainer's manual
-rerun of the required workflow's own existing run for current HEAD
-(`gh run rerun <run-id>` targeting that run, or the Actions UI —
-rerunning the companion workflow's evicting run instead just reclassifies
-the same ordinary comment and no-ops again), creates a fresh trigger and
-clears the stale state. A fresh bot review is not a reliable recovery
-path here either — the same bot-gated `action_required` risk noted above
-(a `pull_request_review`-triggered run for the required workflow can
+**Self-healing recovery**: a subsequent push creates a fresh run
+instance and clears the stale state. A maintainer's manual rerun of the
+required workflow's own existing run for current HEAD (`gh run rerun
+<run-id>` targeting that run, or the Actions UI — rerunning the
+companion workflow's evicting run instead just reclassifies the same
+ordinary comment and no-ops again) forces that same existing run to
+execute again rather than creating a new instance, which can also clear
+the stale state. A fresh bot review is not a reliable recovery path
+here either — the same bot-gated `action_required` risk noted above (a
+`pull_request_review`-triggered run for the required workflow can
 re-enter `action_required` instead of completing) applies to this
 residual too.
 

--- a/.github/instructions/idd-ci.instructions.md
+++ b/.github/instructions/idd-ci.instructions.md
@@ -293,30 +293,38 @@ instead of clearing the rollup.
 **Queue-eviction of a queued comment-triggered refresh (`#177`)**:
 `idd-advisory-convergence-comment.yml`'s own concurrency group uses
 `cancel-in-progress: false`, grouped by PR number, which queues at
-most one pending run per PR — distinct from the required
-`idd-advisory-convergence.yml` workflow's own group, which sets
-`cancel-in-progress: true` and cancels rather than queues. If an
-IDD-originated
-comment's triggered run is queued behind an already-executing run, and
-a later ORDINARY (non-IDD) comment arrives before the first finishes,
-GitHub Actions' own queue-depth-1 behavior evicts the queued
-IDD-originated run in favor of the newer one. The classify step
-(`review-comment-origin.mjs`) only inspects the current triggering
-comment's own body, not full PR state, so the evicting run correctly —
-from its own narrow per-event view — classifies itself
-non-IDD-originated and takes no action; the evicted refresh is lost
-until another trigger fires.
+most one pending run per PR. The required `idd-advisory-convergence.yml`
+workflow's own group queues at most one pending run the same way — GitHub
+always evicts an older pending run in a concurrency group on a new
+trigger, regardless of `cancel-in-progress` — but that required group
+additionally sets `cancel-in-progress: true`, which also cancels its own
+currently-running instance; the companion workflow leaves an
+already-running instance alone. If an IDD-originated comment's triggered
+run is queued behind an already-executing run, and a later ORDINARY
+(non-IDD) comment arrives before the first finishes, this pending-run
+eviction replaces the queued IDD-originated run with the newer one. The
+classify step (`review-comment-origin.mjs`) only inspects the triggering
+event's own comment body — the current body, plus the pre-edit body on an
+`edited` event — never full PR state, so the evicting run correctly —
+from its own narrow per-event view — classifies itself non-IDD-originated
+and takes no action; the evicted refresh is lost until another trigger
+fires.
 This is accepted as a residual of the workflow's own narrow, per-event
-classify-step design, not a defect to silently patch — no fix was
-found that doesn't trade away that design principle (evaluating full
-current PR state instead of just the triggering comment would be a
-real architectural change with its own tradeoffs, not an
-obviously-better alternative). **Self-healing recovery**: a subsequent
-push or a maintainer's manual rerun (`gh run rerun <run-id>` or the
-Actions UI) creates a fresh trigger and clears the stale state. A
-fresh bot review is not a reliable recovery path here either — the
-same bot-gated `action_required` risk noted above (a
-`pull_request_review`-triggered run for the required workflow can
+classify-step design, not a defect to silently patch — no fix was found
+that clearly improves on this without its own tradeoffs: evaluating full
+current PR state instead of just the triggering comment would be a real
+architectural change, and even a narrower per-event alternative — keying
+the concurrency group by comment id instead of PR number — would trade
+away the shared per-PR serialization that prevents concurrent reruns of
+the same required-check run; neither is an obviously-better alternative.
+**Self-healing recovery**: a subsequent push, or a maintainer's manual
+rerun of the required workflow's own existing run for current HEAD
+(`gh run rerun <run-id>` targeting that run, or the Actions UI —
+rerunning the companion workflow's evicting run instead just reclassifies
+the same ordinary comment and no-ops again), creates a fresh trigger and
+clears the stale state. A fresh bot review is not a reliable recovery
+path here either — the same bot-gated `action_required` risk noted above
+(a `pull_request_review`-triggered run for the required workflow can
 re-enter `action_required` instead of completing) applies to this
 residual too.
 

--- a/.github/instructions/idd-ci.instructions.md
+++ b/.github/instructions/idd-ci.instructions.md
@@ -293,12 +293,14 @@ instead of clearing the rollup.
 **Queue-eviction of a queued comment-triggered refresh (`#177`)**:
 `idd-advisory-convergence-comment.yml`'s own concurrency group uses
 `cancel-in-progress: false`, grouped by PR number, which queues at
-most one pending run per PR. The required `idd-advisory-convergence.yml`
-workflow's own group queues at most one pending run the same way — GitHub
-always evicts an older pending run in a concurrency group on a new
-trigger, regardless of `cancel-in-progress` — but that required group
-additionally sets `cancel-in-progress: true`, which also cancels its own
-currently-running instance; the companion workflow leaves an
+most one pending run per PR (GitHub's default `queue: single` behavior
+— neither workflow sets `queue: max`, the newer opt-in that allows up
+to 100 pending runs). The required `idd-advisory-convergence.yml`
+workflow's own group queues the same single-pending way — under this
+default, GitHub evicts an older pending run in a concurrency group on
+a new trigger regardless of `cancel-in-progress` — but that required
+group additionally sets `cancel-in-progress: true`, which also cancels
+its own currently-running instance; the companion workflow leaves an
 already-running instance alone. If an IDD-originated comment's triggered
 run is queued behind an already-executing run, and a later ORDINARY
 (non-IDD) comment arrives before the first finishes, this pending-run
@@ -318,14 +320,14 @@ the concurrency group by comment id instead of PR number — would trade
 away the shared per-PR serialization that prevents concurrent reruns of
 the same required-check run; neither is an obviously-better alternative.
 **Self-healing recovery**: a subsequent push creates a fresh run
-instance and clears the stale state. A maintainer's manual rerun of the
-required workflow's own existing run for current HEAD (`gh run rerun
-<run-id>` targeting that run, or the Actions UI — rerunning the
-companion workflow's evicting run instead just reclassifies the same
-ordinary comment and no-ops again) forces that same existing run to
-execute again rather than creating a new instance, which can also clear
-the stale state. A fresh bot review is not a reliable recovery path
-here either — the same bot-gated `action_required` risk noted above (a
+instance and clears the stale state. A maintainer can also clear it by
+forcing the required workflow's own existing run for current HEAD to
+execute again — `gh run rerun <run-id>` targeting that run, or the
+Actions UI — which reuses the existing run rather than creating a new
+instance; never rerun the companion workflow's evicting run instead,
+which just reclassifies the same ordinary comment and no-ops again. A
+fresh bot review is not a reliable recovery path here either — the
+same bot-gated `action_required` risk noted above (a
 `pull_request_review`-triggered run for the required workflow can
 re-enter `action_required` instead of completing) applies to this
 residual too.

--- a/.github/instructions/idd-ci.instructions.md
+++ b/.github/instructions/idd-ci.instructions.md
@@ -294,8 +294,9 @@ instead of clearing the rollup.
 `idd-advisory-convergence-comment.yml`'s own concurrency group uses
 `cancel-in-progress: false`, grouped by PR number, which queues at
 most one pending run per PR — distinct from the required
-`idd-advisory-convergence.yml` workflow's own `cancel-in-progress:
-true` group, which cancels rather than queues. If an IDD-originated
+`idd-advisory-convergence.yml` workflow's own group, which sets
+`cancel-in-progress: true` and cancels rather than queues. If an
+IDD-originated
 comment's triggered run is queued behind an already-executing run, and
 a later ORDINARY (non-IDD) comment arrives before the first finishes,
 GitHub Actions' own queue-depth-1 behavior evicts the queued

--- a/.github/instructions/lite/idd-ci-lite.instructions.md
+++ b/.github/instructions/lite/idd-ci-lite.instructions.md
@@ -163,10 +163,12 @@ CI-polling shared helper file), never this one. Read
   queues at most one pending run per PR; a later ordinary (non-IDD)
   comment's own run can evict an already-queued IDD-originated refresh
   before it runs, since the classify step judges only the triggering
-  comment's own body. Accepted as a residual of that narrow per-event
-  design; self-heals on the next push or maintainer manual rerun — a
-  fresh bot review is not reliable here either (same gated
-  `action_required` risk as above).
+  comment's body (current, plus the pre-edit body on an edit). Accepted
+  as a residual of that narrow per-event design; self-heals on the next
+  push or a maintainer's manual rerun of the required workflow's own
+  existing run (not the companion workflow's evicting run, which just
+  no-ops again) — a fresh bot review is not reliable here either (same
+  gated `action_required` risk as above).
 
 ## Wake-up discipline
 

--- a/.github/instructions/lite/idd-ci-lite.instructions.md
+++ b/.github/instructions/lite/idd-ci-lite.instructions.md
@@ -165,9 +165,10 @@ CI-polling shared helper file), never this one. Read
   before it runs, since the classify step judges only the triggering
   comment's body (current, plus the pre-edit body on an edit). Accepted
   as a residual of that narrow per-event design; self-heals on the next
-  push or a maintainer's manual rerun of the required workflow's own
-  existing run (not the companion workflow's evicting run, which just
-  no-ops again) — a fresh bot review is not reliable here either (same
+  push (a fresh run instance), or a maintainer forcing the required
+  workflow's own existing run to execute again (not the companion
+  workflow's evicting run, which just no-ops again) — a fresh bot
+  review is not reliable here either (same
   gated `action_required` risk as above).
 
 ## Wake-up discipline

--- a/.github/instructions/lite/idd-ci-lite.instructions.md
+++ b/.github/instructions/lite/idd-ci-lite.instructions.md
@@ -164,8 +164,9 @@ CI-polling shared helper file), never this one. Read
   comment's own run can evict an already-queued IDD-originated refresh
   before it runs, since the classify step judges only the triggering
   comment's own body. Accepted as a residual of that narrow per-event
-  design; self-heals on the next push, fresh bot review, or
-  maintainer manual rerun.
+  design; self-heals on the next push or maintainer manual rerun — a
+  fresh bot review is not reliable here either (same gated
+  `action_required` risk as above).
 
 ## Wake-up discipline
 

--- a/.github/instructions/lite/idd-ci-lite.instructions.md
+++ b/.github/instructions/lite/idd-ci-lite.instructions.md
@@ -158,6 +158,14 @@ CI-polling shared helper file), never this one. Read
   manual rerun (forces the same run to execute again, not a guaranteed
   pass, without granting a fresh budget). A fresh bot review is not
   reliable here — it can itself re-enter `action_required`.
+- Queue-eviction of a queued comment-triggered refresh (`#177`): the
+  companion workflow's `cancel-in-progress: false` concurrency group
+  queues at most one pending run per PR; a later ordinary (non-IDD)
+  comment's own run can evict an already-queued IDD-originated refresh
+  before it runs, since the classify step judges only the triggering
+  comment's own body. Accepted as a residual of that narrow per-event
+  design; self-heals on the next push, fresh bot review, or
+  maintainer manual rerun.
 
 ## Wake-up discipline
 


### PR DESCRIPTION
## Summary

Documents `idd-advisory-convergence-comment.yml`'s queue-eviction
residual (issue `#163`) as accepted, intentional, bounded-recovery
behavior of its own narrow, per-event classify-step design.

- `.github/instructions/idd-ci.instructions.md`: new paragraph in the
  Rerun mechanics section (directly after the existing `#171`
  "Shared rerun-once budget" paragraph added by PR #176, before the
  Interpretation table) covering: (1) the queue-eviction mechanism —
  the companion workflow's `cancel-in-progress: false` concurrency
  group (grouped by PR number) queues at most one pending run per PR,
  so a later ordinary (non-IDD) comment's own run can evict an
  already-queued IDD-originated refresh before it runs, since the
  classify step only inspects the triggering comment's own body, not
  full PR state; (2) that this is accepted as a residual of the
  workflow's own narrow design, with no fix found that doesn't trade
  that design away; (3) the self-healing recovery path (a subsequent
  push, fresh bot review, or maintainer manual rerun creates a fresh
  trigger and clears the stale state).
- `.github/instructions/lite/idd-ci-lite.instructions.md`: an
  equivalently condensed bullet directly after the existing `#171`
  bullet in its own Rerun mechanics section.

No changes to any workflow YAML, vendored script, or file outside
these two instruction files — this is a documentation-only change.

## Background/rationale

While closing #171 (a distinct shared rerun-once-budget residual), a
second residual surfaced on that issue's own thread: this workflow's
`cancel-in-progress: false` concurrency group has depth-1 queuing, so
a queued IDD-originated refresh can be silently evicted by a later
ordinary comment's own run before it ever executes. Verified directly
against the workflow files before writing: `idd-advisory-convergence
-comment.yml` uses `cancel-in-progress: false` grouped by PR number,
while the required `idd-advisory-convergence.yml` uses
`cancel-in-progress: true` (a genuinely different mechanism, cited
here only as a verified factual contrast — not as prior precedent for
this residual). No mechanical fix was found that doesn't trade away
the companion workflow's narrow per-event classify-step design
(evaluating full current PR state instead of just the triggering
comment would be a real architectural change), so the right-sized
response is documenting the residual with its own recovery guidance,
matching `#171`'s own resolution shape.

Closes #177
