### PR TITLE
docs(idd): document the review-ack marker mechanism

### DIFF
--- a/.github/instructions/idd-advisory-wait.instructions.md
+++ b/.github/instructions/idd-advisory-wait.instructions.md
@@ -334,6 +334,11 @@ post-idd-marker command (`--type advisory-reroll --target pr
 be posted or verified, fail closed to AW4's **Recovery failed** hold
 (mirrors AW3-R's routing on the same failure).
 
+**Already-handled escape hatch**: when the blocking suppressed
+finding(s) have already been read and handled, a reroll is
+unnecessary — post a trusted `review-ack:` marker instead; see
+`idd-review-triage.instructions.md`'s `review-ack:` paragraph (E6).
+
 ## Terminal Copilot stall-recovery contract (state, policy, markers, clock)
 
 `#1572` defines the state/policy/marker contract for a terminal

--- a/.github/instructions/idd-pre-merge.instructions.md
+++ b/.github/instructions/idd-pre-merge.instructions.md
@@ -292,7 +292,10 @@ nonce was recorded for the active claim.
   profile-selected `idd-advisory-convergence` command). Non-zero exit is
   a hard merge block — route to E1/E4 (check **AW6** first when
   `sameHeadReroll.eligible`) using `reasons`; zero exit (`ready: true`)
-  satisfies this condition.
+  satisfies this condition. An `ack-suppressed` next-action from AW6
+  means Clause 1's `suppressedCount` term still needs coverage — see
+  `idd-review-triage.instructions.md`'s `review-ack:` paragraph (E6)
+  instead of rerolling.
   Separately, require `dispositionEvidence.route` to be `proceed`
   (`dispositionEvidence.blockingCount == 0` — both
   `missingRegularComments` (any outstanding non-thread regular PR

--- a/.github/instructions/idd-pre-merge.instructions.md
+++ b/.github/instructions/idd-pre-merge.instructions.md
@@ -294,6 +294,7 @@ nonce was recorded for the active claim.
   `sameHeadReroll.eligible`) using `reasons`; zero exit (`ready: true`)
   satisfies this condition. An `ack-suppressed` next-action from AW6
   means Clause 1's `suppressedCount` term still needs coverage — see
+  AW6's "Already-handled escape hatch" and
   `idd-review-triage.instructions.md`'s `review-ack:` paragraph (E6)
   instead of rerolling.
   Separately, require `dispositionEvidence.route` to be `proceed`

--- a/.github/instructions/idd-review-triage.instructions.md
+++ b/.github/instructions/idd-review-triage.instructions.md
@@ -301,10 +301,18 @@ of a comment, so it has no thread or comment ID of its own to reply
 to — see `docs/idd-helper-scripts.md`), Clause 1's `suppressedCount`
 term needs its own coverage
 (`suppressedCount === 0 || hasValidReviewAck`) regardless of any
-Clause 2 disposition elsewhere in the same review. After reading the
-review body and confirming the suppressed finding(s) are handled
-(fixed, or judged as needing no action), post `review-ack:` for the
-current HEAD SHA. Posting performs no author gating on its own —
+Clause 2 disposition elsewhere in the same review. `hasValidReviewAck`
+is purely temporal (the marker's own `created_at` postdating the
+inspected review's `submittedAt`, never an embedded review ID), so a
+newer same-HEAD review landing between reading the review body and
+posting the marker is not detected by HEAD SHA alone — immediately
+before posting, re-fetch the latest Copilot review and confirm it is
+still the one whose suppressed finding(s) you inspected; if a newer
+same-HEAD review has landed instead, read that one first. After
+reading the review body and confirming the suppressed finding(s) are
+handled (fixed, or judged as needing no action), post `review-ack:`
+for the current HEAD SHA. Posting performs no author gating on its
+own —
 anyone with `gh` credentials can post the comment — but
 `idd-advisory-convergence` only honors a marker whose GitHub author is
 a `trustedMarkerActors` login; an untrusted poster's marker is ignored,
@@ -324,7 +332,8 @@ and neither that check's own workflow nor its comment-triggered
 companion listens for a regular (non-review-thread) comment event — so
 after the marker is verified, also rerun the existing PR-linked run for
 the current HEAD (`gh run rerun <run-id>`, or the profile-selected
-`idd-rerun-advisory-convergence` command; see
+`idd-rerun-advisory-convergence --pr <pr-number> --apply` command,
+which is read-only diagnosis without `--apply`; see
 [Rerun mechanics](idd-ci.instructions.md#rerun-mechanics)); the marker
 alone does not retrigger the check.
 

--- a/.github/instructions/idd-review-triage.instructions.md
+++ b/.github/instructions/idd-review-triage.instructions.md
@@ -318,6 +318,16 @@ when helper runtime is unavailable:
 review-ack: {agent-id} {PR_HEAD_SHA} {ISO8601-acknowledged-at}
 ```
 
+Posting the marker does not by itself refresh a failed
+`idd-advisory-convergence` run — the marker is a regular PR comment,
+and neither that check's own workflow nor its comment-triggered
+companion listens for a regular (non-review-thread) comment event — so
+after the marker is verified, also rerun the existing PR-linked run for
+the current HEAD (`gh run rerun <run-id>`, or the profile-selected
+`idd-rerun-advisory-convergence` command; see
+[Rerun mechanics](idd-ci.instructions.md#rerun-mechanics)); the marker
+alone does not retrigger the check.
+
 _Worked example_: a review posts a regular-comment finding plus a
 suppressed one. Disposition the regular-comment finding normally
 (`**Rejected** — verified placeholders-only`), then also post

--- a/.github/instructions/idd-review-triage.instructions.md
+++ b/.github/instructions/idd-review-triage.instructions.md
@@ -335,7 +335,14 @@ the current HEAD (`gh run rerun <run-id>`, or the profile-selected
 `idd-rerun-advisory-convergence --pr <pr-number> --apply` command,
 which is read-only diagnosis without `--apply`; see
 [Rerun mechanics](idd-ci.instructions.md#rerun-mechanics)); the marker
-alone does not retrigger the check.
+alone does not retrigger the check. If the helper reports
+`rerunPolicyHoldNotice` (the shared `ciWait.rerunPolicy` budget for
+this HEAD is already exhausted, even with `--apply`), a trusted
+maintainer's plain `gh run rerun <run-id>` on each remaining
+non-passing instance is not bound by that automation-only budget (see
+[Rerun mechanics](idd-ci.instructions.md#rerun-mechanics)'s
+self-healing-recovery note); absent that, post a hold and stop rather
+than leaving the check permanently red.
 
 _Worked example_: a review posts a regular-comment finding plus a
 suppressed one. Disposition the regular-comment finding normally

--- a/.github/instructions/idd-review-triage.instructions.md
+++ b/.github/instructions/idd-review-triage.instructions.md
@@ -292,6 +292,41 @@ PATH B — Advisory items (completed review of the current HEAD):
 - Do not send PATH B items to review-fix. Their work is complete once
   the marker is posted and any thread resolution is done.
 
+**`review-ack:` marker — Clause 1 vs Clause 2.** Posting `**Accepted**`
+/ `**Rejected**` above satisfies advisory-convergence's Clause 2
+(thread / comment disposition) only. When the latest Copilot review on
+current HEAD also reports `suppressedCount > 0` (a finding folded into
+a `<details><summary>Suppressed comments (N)</summary>` block instead
+of a comment, so it has no thread or comment ID of its own to reply
+to — see `docs/idd-helper-scripts.md`), Clause 1's `suppressedCount`
+term needs its own coverage
+(`suppressedCount === 0 || hasValidReviewAck`) regardless of any
+Clause 2 disposition elsewhere in the same review. After reading the
+review body and confirming the suppressed finding(s) are handled
+(fixed, or judged as needing no action), post `review-ack:` for the
+current HEAD SHA. Posting performs no author gating on its own —
+anyone with `gh` credentials can post the comment — but
+`idd-advisory-convergence` only honors a marker whose GitHub author is
+a `trustedMarkerActors` login; an untrusted poster's marker is ignored,
+not rejected at post time. Helper-first: the profile-selected
+post-idd-marker command (`--type review-ack --from-pr <pr-number>
+--agent-id <id> --timestamp <ISO8601> --apply`; see
+`docs/idd-helper-scripts.md`); the manual JSON `POST` is the fallback
+when helper runtime is unavailable:
+
+```text
+review-ack: {agent-id} {PR_HEAD_SHA} {ISO8601-acknowledged-at}
+```
+
+_Worked example_: a review posts a regular-comment finding plus a
+suppressed one. Disposition the regular-comment finding normally
+(`**Rejected** — verified placeholders-only`), then also post
+`review-ack: claude-code-1a2b3c4d 4b825dc642cb6eb9a060e54bf8d69288fbee4904 2026-08-19T00:10:00Z`
+(plain text, no HTML comment) to cover the suppressed one — the
+regular-comment rejection alone never sets `converged`, and this is
+not a license to skip **AW6** or the fix flow when the suppressed
+finding needs a code change.
+
 PATH B — Advisory non-review notice (rate-limit / quota / queued / bare
 ack / error, as defined in E4):
 


### PR DESCRIPTION
## Summary

- Document the `review-ack:` marker mechanism (already live and enforced
  by `idd-advisory-convergence`, but previously undocumented locally) in
  the three local instruction files that upstream `kurone-kito/idd-skill`
  documents it in, reconciling upstream `v0.7.0` wording (pinned commit
  `f51a8bb7`) while preserving this repository's own local conventions
  (profile-selected `post-idd-marker` command phrasing, manual JSON
  `POST` fallback wording).
- `idd-review-triage.instructions.md` (E6): added the `review-ack:`
  marker's own contract — the Clause 1 vs Clause 2 distinction, exact
  marker format, and worked example.
- `idd-advisory-wait.instructions.md` (AW6): added the "already-handled
  escape hatch" cross-reference — post `review-ack:` instead of a
  same-HEAD reroll when the blocking suppressed finding(s) are already
  handled.
- `idd-pre-merge.instructions.md` (F2, Advisory convergence): added the
  `ack-suppressed` next-action cross-reference back to the
  `idd-review-triage.instructions.md` paragraph above.

## Lite counterparts

No lite file (`idd-advisory-wait-lite.instructions.md`,
`idd-pre-merge-lite.instructions.md`, `idd-review-fix-lite.instructions.md`)
was changed. Two convergent reasons:

- **Empirical**: upstream at the pinned commit carries zero `review-ack`
  mentions in any lite file either.
- **Structural**: each candidate lite file's own scope boundary excludes
  exactly the content `review-ack:` lives in —
  `idd-advisory-wait-lite.instructions.md` explicitly excludes the
  same-HEAD advisory reroll (AW6) as an "F2/F3-only mechanism this file
  does not reproduce"; `idd-pre-merge-lite.instructions.md`'s F2 is a
  helper-read-only pass-through that explicitly will not "interpret,
  re-route, or attempt to remedy individual blockers"; and
  `idd-review-fix-lite.instructions.md` explicitly excludes E4-E8
  judgment calls, which is exactly what deciding to post `review-ack:` is.

## Deliberately not adopted from the same upstream diff hunks

Diffing against upstream surfaced several unrelated wording drifts already
present in this repository's copies, independent of the `review-ack:` gap
this issue scopes: a reply-identity-stamp paragraph
(`<!-- {markerPrefix}-review-reply -->`), a "paraphrase a bot's trigger
string" paragraph, and a `#1934` suppressedCount-reroll-reliability note.
None of these are the named gap, so none were touched here, per the
issue's own named-gap-reconciliation scope (not a wholesale file
overwrite).

## Validation

- `pnpm run lint:fix && pnpm run lint` — clean, no fixes needed.
- `pnpm run build` / `pnpm run test` — pass (91 tests).
- `pnpm exec idd-doctor` — passed, 1 pre-existing warning (release-tag
  drift), no stale-import warning for this file set.

Closes #178
