### PR TITLE
fix(sea-builder): re-verify cache-hit archives against SHASUMS256.txt

### DIFF
--- a/packages/sea-builder/README.md
+++ b/packages/sea-builder/README.md
@@ -55,10 +55,11 @@ the build output.
 
 All downloaded archives are stored in your home directory's
 `.cache/xsea` folder — the same location `xsea` itself reads them from.
-When `sea-cache`/`sea-builder`
-populate an entry, the archive is downloaded and SHA-256-verified before
-`xsea` ever sees it, so `xsea` links exactly the bytes that passed
-verification. This is a fixed location outside any project directory:
+Every archive `sea-cache`/`sea-builder` uses is SHA-256-verified against
+the published `SHASUMS256.txt` before `xsea` ever sees it, so `xsea`
+links exactly the bytes that passed verification — including an archive
+that was already present in the cache directory, not just a fresh
+download. This is a fixed location outside any project directory:
 
 - Each package's `clean` script no longer clears this cache (it only
   removes project-local build artifacts). Run
@@ -69,8 +70,9 @@ verification. This is a fixed location outside any project directory:
   do not collide.
 - An archive already present in this directory — for example, from
   running `xsea` directly instead of through `sea-cache`/`sea-builder` —
-  is treated as a cache hit like any pre-populated cache entry and is not
-  re-verified.
+  is re-verified against the published checksum before being trusted,
+  the same as a fresh download. A stale or foreign file that fails
+  verification is removed and re-downloaded automatically.
 
 ## LICENSE
 

--- a/packages/sea-builder/src/listr2/createBuildTasks.mts
+++ b/packages/sea-builder/src/listr2/createBuildTasks.mts
@@ -27,8 +27,15 @@ export const createBuildTasks = async (
   options: BuildTasksOptions,
 ): Promise<Listr> => {
   const { arch, platform = process.platform } = options;
-  const { basename, download, execa, existsSync, mkdir, targets } =
-    await normalizeBuildOptions(options);
+  const {
+    basename,
+    download,
+    execa,
+    existsSync,
+    mkdir,
+    targets,
+    verifyCachedArchive,
+  } = await normalizeBuildOptions(options);
   const nodeVersion = await resolveNodeVersion(options.nodeVersion);
   return new Listr([
     createBuildTask(execa),
@@ -40,6 +47,7 @@ export const createBuildTasks = async (
       nodeVersion,
       platform,
       targets,
+      verifyCachedArchive,
     }),
     createSeaTask(execa, targets, basename, nodeVersion),
   ]);

--- a/packages/sea-builder/src/tasks/createCacheTask.spec.mts
+++ b/packages/sea-builder/src/tasks/createCacheTask.spec.mts
@@ -5,6 +5,11 @@ const opts = {
   download: vi.fn(),
   existsSync: vi.fn(() => true),
   mkdir: vi.fn(async () => undefined),
+  // Without an explicit override, a cache "hit" (existsSync -> true)
+  // would fall through to the real checksum re-verification and its
+  // live SHASUMS256.txt fetch -- mock it so this stays a pure unit
+  // test, mirroring the other injected fs/network functions above.
+  verifyCachedArchive: vi.fn(async () => true),
 };
 
 describe('createCacheTask', () => {

--- a/packages/sea-builder/src/tasks/createCacheTasks.mts
+++ b/packages/sea-builder/src/tasks/createCacheTasks.mts
@@ -1,5 +1,10 @@
 import { resolveNodeVersion } from '../utils/resolveNodeVersion.mjs';
-import type { DownloadFunction, ExistsSync, Mkdir } from '../utils/types.mjs';
+import type {
+  DownloadFunction,
+  ExistsSync,
+  Mkdir,
+  VerifyCachedArchiveFunction,
+} from '../utils/types.mjs';
 import { createMetaFactory } from './createMetaFactory.mjs';
 import type { Task } from './createTaskFactory.mjs';
 import { createTaskFactory } from './createTaskFactory.mjs';
@@ -27,6 +32,12 @@ export interface CacheOptions {
 
   /** Target strings such as `linux-x64`. */
   readonly targets?: readonly string[] | undefined;
+
+  /**
+   * Function that re-verifies an existing cache-hit archive against its
+   * published checksum.
+   */
+  readonly verifyCachedArchive?: VerifyCachedArchiveFunction | undefined;
 }
 
 /**
@@ -41,12 +52,25 @@ export interface CacheOptions {
 export const createCacheTasks = async (
   options: CacheOptions = {},
 ): Promise<Task[]> => {
-  const { cacheDir, download, existsSync, mkdir, nodeVersion, targets } =
-    normalizeCacheOptions({
-      ...options,
-      nodeVersion: await resolveNodeVersion(options.nodeVersion),
-    });
+  const {
+    cacheDir,
+    download,
+    existsSync,
+    mkdir,
+    nodeVersion,
+    targets,
+    verifyCachedArchive,
+  } = normalizeCacheOptions({
+    ...options,
+    nodeVersion: await resolveNodeVersion(options.nodeVersion),
+  });
   const metaFor = createMetaFactory(cacheDir, nodeVersion);
-  const toTask = createTaskFactory(download, existsSync, mkdir, cacheDir);
+  const toTask = createTaskFactory(
+    download,
+    verifyCachedArchive,
+    existsSync,
+    mkdir,
+    cacheDir,
+  );
   return targets.map((t) => toTask(metaFor(t)));
 };

--- a/packages/sea-builder/src/tasks/createTaskFactory.mts
+++ b/packages/sea-builder/src/tasks/createTaskFactory.mts
@@ -3,7 +3,10 @@ import type {
   mkdirSync as concretedMkdirSync,
 } from 'node:fs';
 import type { mkdir as concretedMkdir } from 'node:fs/promises';
-import type { DownloadFunction } from '../utils/types.mjs';
+import type {
+  DownloadFunction,
+  VerifyCachedArchiveFunction,
+} from '../utils/types.mjs';
 import type { ArchiveMeta } from './createMetaFactory.mjs';
 
 /** Type definition for a Listr task that downloads Node.js archives. */
@@ -18,6 +21,9 @@ export interface Task {
 /**
  * Create a function that converts metadata into a Listr task.
  * @param download File download function.
+ * @param verifyCachedArchive Function that re-verifies an existing
+ *   cache-hit archive against its published checksum, removing it and
+ *   returning `false` when it cannot be verified.
  * @param existsSync File existence check function.
  * @param mkdir Directory creation function.
  * @param cacheDir Directory for cached archives.
@@ -26,6 +32,7 @@ export interface Task {
 export const createTaskFactory =
   (
     download: DownloadFunction,
+    verifyCachedArchive: VerifyCachedArchiveFunction,
     existsSync: typeof concretedExistsSync,
     mkdir: typeof concretedMkdirSync | typeof concretedMkdir,
     cacheDir: string,
@@ -35,7 +42,17 @@ export const createTaskFactory =
     return {
       task: async () => {
         await mkdir(cacheDir, { recursive: true });
-        if (!existsSync(archivePath)) {
+        // A cache "hit" only counts once the file re-verifies against
+        // the published checksum -- see verifyCachedArchive's own doc
+        // comment for why an unverified existing file cannot be trusted
+        // now that this cache directory is shared with xsea. The
+        // short-circuit keeps a genuine cache miss (existsSync false) at
+        // zero extra network cost: verifyCachedArchive's own
+        // SHASUMS256.txt fetch only runs on an actual hit.
+        const cacheHit =
+          existsSync(archivePath) &&
+          (await verifyCachedArchive(url, archivePath));
+        if (!cacheHit) {
           await download(url, archivePath);
         }
       },

--- a/packages/sea-builder/src/tasks/createTaskFactory.spec.mts
+++ b/packages/sea-builder/src/tasks/createTaskFactory.spec.mts
@@ -9,28 +9,68 @@ describe('createTaskFactory', () => {
     url: 'https://example.com/node.tar.gz',
   };
 
-  it('downloads archive when missing', async () => {
+  it('downloads archive when missing, without verifying a cache hit', async () => {
     const download = vi.fn();
+    const verifyCachedArchive = vi.fn();
     const existsSync = vi.fn(() => false);
     const mkdir = vi.fn(async () => undefined);
-    const factory = createTaskFactory(download, existsSync, mkdir, '/cache');
+    const factory = createTaskFactory(
+      download,
+      verifyCachedArchive,
+      existsSync,
+      mkdir,
+      '/cache',
+    );
     await factory(meta).task();
     expect(mkdir).toHaveBeenCalledWith('/cache', { recursive: true });
+    expect(verifyCachedArchive).not.toHaveBeenCalled();
     expect(download).toHaveBeenCalledWith(meta.url, meta.archivePath);
   });
 
-  it('skips download when archive exists', async () => {
+  it('skips download on a cache hit with a matching checksum', async () => {
     const download = vi.fn();
+    const verifyCachedArchive = vi.fn(async () => true);
     const existsSync = vi.fn(() => true);
     const mkdir = vi.fn(async () => undefined);
-    const factory = createTaskFactory(download, existsSync, mkdir, '/cache');
+    const factory = createTaskFactory(
+      download,
+      verifyCachedArchive,
+      existsSync,
+      mkdir,
+      '/cache',
+    );
     await factory(meta).task();
+    expect(verifyCachedArchive).toHaveBeenCalledWith(
+      meta.url,
+      meta.archivePath,
+    );
     expect(download).not.toHaveBeenCalled();
+  });
+
+  it('downloads when a cache hit fails checksum re-verification', async () => {
+    const download = vi.fn();
+    const verifyCachedArchive = vi.fn(async () => false);
+    const existsSync = vi.fn(() => true);
+    const mkdir = vi.fn(async () => undefined);
+    const factory = createTaskFactory(
+      download,
+      verifyCachedArchive,
+      existsSync,
+      mkdir,
+      '/cache',
+    );
+    await factory(meta).task();
+    expect(verifyCachedArchive).toHaveBeenCalledWith(
+      meta.url,
+      meta.archivePath,
+    );
+    expect(download).toHaveBeenCalledWith(meta.url, meta.archivePath);
   });
 
   it('sets task title to target', () => {
     const factory = createTaskFactory(
       vi.fn(),
+      vi.fn(async () => true),
       vi.fn(() => true),
       vi.fn(async () => undefined),
       '/cache',

--- a/packages/sea-builder/src/tasks/normalizeBuildOptions.mts
+++ b/packages/sea-builder/src/tasks/normalizeBuildOptions.mts
@@ -31,6 +31,7 @@ export const normalizeBuildOptions = async (
     nodeVersion: cacheOpts.nodeVersion,
     platform: cacheOpts.platform,
     targets: cacheOpts.targets,
+    verifyCachedArchive: cacheOpts.verifyCachedArchive,
   });
   return { ...normalized, basename, execa };
 };

--- a/packages/sea-builder/src/tasks/normalizeCacheOptions.mts
+++ b/packages/sea-builder/src/tasks/normalizeCacheOptions.mts
@@ -4,6 +4,7 @@ import type { SetNonNullable } from 'type-fest';
 import { CACHE_DIR } from '../constants.mjs';
 import { downloadArchive } from '../utils/downloadArchive.mjs';
 import { normalizeTargets } from '../utils/normalizeTargets.mjs';
+import { verifyCachedArchive as concretedVerifyCachedArchive } from '../utils/verifyCachedArchive.mjs';
 import type { CacheOptions } from './createCacheTasks.mjs';
 
 /** Type definition for options accepted by {@link normalizeCacheOptions}. */
@@ -29,6 +30,7 @@ export const normalizeCacheOptions = (
     nodeVersion = `v${process.versions.node}`,
     platform = process.platform,
     targets = [],
+    verifyCachedArchive = concretedVerifyCachedArchive,
   } = options;
   return {
     cacheDir: CACHE_DIR,
@@ -39,5 +41,6 @@ export const normalizeCacheOptions = (
     download,
     existsSync,
     mkdir,
+    verifyCachedArchive,
   };
 };

--- a/packages/sea-builder/src/utils/downloadArchive.mts
+++ b/packages/sea-builder/src/utils/downloadArchive.mts
@@ -5,10 +5,8 @@ import { basename } from 'node:path/posix';
 import { Readable } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
 import type { ReadableStream as NodeWebReadableStream } from 'node:stream/web';
+import { fetchExpectedChecksum } from './fetchExpectedChecksum.mjs';
 import type { DownloadFunction } from './types.mjs';
-
-/** Matches a 64-character lowercase or uppercase hex SHA-256 digest. */
-const SHA256_HEX = /^[0-9a-fA-F]{64}$/;
 
 /**
  * Convert a Fetch API {@link Response.body} into a Node.js
@@ -25,29 +23,6 @@ const SHA256_HEX = /^[0-9a-fA-F]{64}$/;
  */
 const toNodeReadable = (body: ReadableStream<Uint8Array>): Readable =>
   Readable.fromWeb(body as unknown as NodeWebReadableStream<Uint8Array>);
-
-/**
- * Find the published SHA-256 checksum for a file in a `SHASUMS256.txt`
- * listing.
- * @param shasums Contents of the `SHASUMS256.txt` file.
- * @param filename Archive file name to look up.
- * @returns The expected lowercase hex SHA-256 digest.
- * @throws {Error} If no parseable checksum line names `filename`, or the
- *   token found is not a 64-character hex digest.
- */
-const findExpectedChecksum = (shasums: string, filename: string): string => {
-  const line = shasums
-    .split('\n')
-    .find((l) => l.trim().split(/\s+/).at(-1) === filename);
-  const checksum = line?.trim().split(/\s+/).at(0);
-  if (!checksum) {
-    throw new Error(`No checksum entry found for ${filename}`);
-  }
-  if (!SHA256_HEX.test(checksum)) {
-    throw new Error(`Malformed checksum entry for ${filename}: ${checksum}`);
-  }
-  return checksum.toLowerCase();
-};
 
 /**
  * Move a verified temporary download onto its final destination.
@@ -92,17 +67,7 @@ export const downloadArchive: DownloadFunction = async (url, dest) => {
     throw new Error('Response body is empty');
   }
   const filename = basename(new URL(url).pathname);
-  const shasumsUrl = new URL('SHASUMS256.txt', url);
-  const shasumsResponse = await fetch(shasumsUrl);
-  if (!shasumsResponse.ok) {
-    throw new Error(
-      `Failed to download ${shasumsUrl.toString()}: HTTP ${shasumsResponse.status}`,
-    );
-  }
-  const expectedChecksum = findExpectedChecksum(
-    await shasumsResponse.text(),
-    filename,
-  );
+  const expectedChecksum = await fetchExpectedChecksum(url);
 
   const tempPath = `${dest}.download-${process.pid}-${randomUUID()}`;
   try {

--- a/packages/sea-builder/src/utils/fetchExpectedChecksum.mts
+++ b/packages/sea-builder/src/utils/fetchExpectedChecksum.mts
@@ -1,0 +1,26 @@
+import { basename } from 'node:path/posix';
+import { findExpectedChecksum } from './findExpectedChecksum.mjs';
+
+/**
+ * Fetch `SHASUMS256.txt` alongside {@link url} and look up the published
+ * SHA-256 checksum for the archive it names.
+ *
+ * Shared by the download-time verification in `downloadArchive` and the
+ * cache-hit re-verification in `verifyCachedArchive`, so the
+ * `SHASUMS256.txt` fetch-and-parse logic exists in exactly one place.
+ * @param url Source URL of the archive to look up.
+ * @returns The expected lowercase hex SHA-256 digest.
+ * @throws {Error} If the `SHASUMS256.txt` request fails, or if
+ *   {@link findExpectedChecksum} cannot find or parse a matching entry.
+ */
+export const fetchExpectedChecksum = async (url: string): Promise<string> => {
+  const filename = basename(new URL(url).pathname);
+  const shasumsUrl = new URL('SHASUMS256.txt', url);
+  const response = await fetch(shasumsUrl);
+  if (!response.ok) {
+    throw new Error(
+      `Failed to download ${shasumsUrl.toString()}: HTTP ${response.status}`,
+    );
+  }
+  return findExpectedChecksum(await response.text(), filename);
+};

--- a/packages/sea-builder/src/utils/fetchExpectedChecksum.spec.mts
+++ b/packages/sea-builder/src/utils/fetchExpectedChecksum.spec.mts
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { fetchExpectedChecksum } from './fetchExpectedChecksum.mjs';
+
+const ARCHIVE_NAME = 'node-v22.23.2-linux-x64.tar.gz';
+const ARCHIVE_URL = `https://nodejs.org/dist/v22.23.2/${ARCHIVE_NAME}`;
+const HASH = 'a'.repeat(64);
+
+const shasumsResponse = (body: string, ok = true, status = 200) => ({
+  ok,
+  status,
+  text: async () => body,
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('fetchExpectedChecksum', () => {
+  it('fetches SHASUMS256.txt alongside the archive URL and looks up the checksum', async () => {
+    const fetchMock = vi.fn(async (input: string | URL) => {
+      expect(input.toString()).toBe(
+        'https://nodejs.org/dist/v22.23.2/SHASUMS256.txt',
+      );
+      return shasumsResponse(`${HASH}  ${ARCHIVE_NAME}\n`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(fetchExpectedChecksum(ARCHIVE_URL)).resolves.toBe(HASH);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws for a non-2xx SHASUMS256.txt response', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => shasumsResponse('', false, 404)),
+    );
+
+    await expect(fetchExpectedChecksum(ARCHIVE_URL)).rejects.toThrow(
+      /HTTP 404/,
+    );
+  });
+
+  it('propagates a findExpectedChecksum lookup failure', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => shasumsResponse('deadbeef  some-other-file.tar.gz\n')),
+    );
+
+    await expect(fetchExpectedChecksum(ARCHIVE_URL)).rejects.toThrow(
+      /No checksum entry/,
+    );
+  });
+});

--- a/packages/sea-builder/src/utils/findExpectedChecksum.mts
+++ b/packages/sea-builder/src/utils/findExpectedChecksum.mts
@@ -1,0 +1,28 @@
+/** Matches a 64-character lowercase or uppercase hex SHA-256 digest. */
+const SHA256_HEX = /^[0-9a-fA-F]{64}$/;
+
+/**
+ * Find the published SHA-256 checksum for a file in a `SHASUMS256.txt`
+ * listing.
+ * @param shasums Contents of the `SHASUMS256.txt` file.
+ * @param filename Archive file name to look up.
+ * @returns The expected lowercase hex SHA-256 digest.
+ * @throws {Error} If no parseable checksum line names `filename`, or the
+ *   token found is not a 64-character hex digest.
+ */
+export const findExpectedChecksum = (
+  shasums: string,
+  filename: string,
+): string => {
+  const line = shasums
+    .split('\n')
+    .find((l) => l.trim().split(/\s+/).at(-1) === filename);
+  const checksum = line?.trim().split(/\s+/).at(0);
+  if (!checksum) {
+    throw new Error(`No checksum entry found for ${filename}`);
+  }
+  if (!SHA256_HEX.test(checksum)) {
+    throw new Error(`Malformed checksum entry for ${filename}: ${checksum}`);
+  }
+  return checksum.toLowerCase();
+};

--- a/packages/sea-builder/src/utils/findExpectedChecksum.spec.mts
+++ b/packages/sea-builder/src/utils/findExpectedChecksum.spec.mts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { findExpectedChecksum } from './findExpectedChecksum.mjs';
+
+const FILENAME = 'node-v22.23.2-linux-x64.tar.gz';
+const HASH = 'a'.repeat(64);
+
+describe('findExpectedChecksum', () => {
+  it('finds a lowercase-hex checksum entry', () => {
+    expect(findExpectedChecksum(`${HASH}  ${FILENAME}\n`, FILENAME)).toBe(HASH);
+  });
+
+  it('lowercases an uppercase-hex checksum entry', () => {
+    expect(
+      findExpectedChecksum(`${HASH.toUpperCase()}  ${FILENAME}\n`, FILENAME),
+    ).toBe(HASH);
+  });
+
+  it('finds the matching line among multiple entries', () => {
+    const other = 'b'.repeat(64);
+    const shasums = `${other}  some-other-file.tar.gz\n${HASH}  ${FILENAME}\n`;
+    expect(findExpectedChecksum(shasums, FILENAME)).toBe(HASH);
+  });
+
+  it('throws when no entry names the filename', () => {
+    expect(() =>
+      findExpectedChecksum(`${HASH}  some-other-file.tar.gz\n`, FILENAME),
+    ).toThrow(/No checksum entry/);
+  });
+
+  it('throws when the matching entry is not a 64-character hex digest', () => {
+    expect(() =>
+      findExpectedChecksum(`not-a-hash  ${FILENAME}\n`, FILENAME),
+    ).toThrow(/Malformed checksum entry/);
+  });
+});

--- a/packages/sea-builder/src/utils/types.mts
+++ b/packages/sea-builder/src/utils/types.mts
@@ -12,3 +12,12 @@ export type ExistsSync = typeof existsSync;
 
 /** Type definition for a function that creates directories. */
 export type Mkdir = typeof mkdir | typeof mkdirSync;
+
+/**
+ * Type definition for a function that re-verifies an existing cached
+ * archive file against its published checksum.
+ */
+export type VerifyCachedArchiveFunction = (
+  url: string,
+  archivePath: string,
+) => Promise<boolean>;

--- a/packages/sea-builder/src/utils/verifyCachedArchive.mts
+++ b/packages/sea-builder/src/utils/verifyCachedArchive.mts
@@ -1,0 +1,65 @@
+import { createHash } from 'node:crypto';
+import { createReadStream } from 'node:fs';
+import { rm } from 'node:fs/promises';
+import { fetchExpectedChecksum } from './fetchExpectedChecksum.mjs';
+
+/**
+ * Stream-hash an existing file with SHA-256, matching the chunk-update
+ * pattern `downloadArchive` uses for a fresh download.
+ * @param path Path to the file to hash.
+ * @returns The lowercase hex SHA-256 digest.
+ */
+const hashFile = async (path: string): Promise<string> => {
+  const hash = createHash('sha256');
+  for await (const chunk of createReadStream(path)) {
+    hash.update(chunk as Uint8Array);
+  }
+  return hash.digest('hex');
+};
+
+/**
+ * Re-verify an existing cache-hit archive against the published SHA-256
+ * checksum in `SHASUMS256.txt`, matching the same zero-tolerance
+ * verification `downloadArchive` performs on a fresh download.
+ *
+ * Now that `sea-builder` shares its cache directory and filename
+ * convention with `xsea`'s own unverified `fetch` → write, an existing
+ * file at {@link archivePath} may never have been checksum-verified.
+ * This closes that gap: on any failure to confirm the checksum — a
+ * mismatch, or an error fetching or parsing `SHASUMS256.txt`, or a file
+ * read error — the file at {@link archivePath} is removed so the caller
+ * can fall through to a fresh, verified `downloadArchive` call, matching
+ * the "leaves no file behind" self-healing philosophy `downloadArchive`
+ * already documents for an interrupted download.
+ *
+ * The stale-file removal deliberately propagates its own failure rather
+ * than being swallowed: `downloadArchive`'s internal `moveIntoPlace`
+ * helper treats an already-present destination file as evidence that a
+ * concurrent caller already checksum-verified it (its Windows
+ * `EPERM`/`EBUSY` recovery path). If a failed `rm` here were silently
+ * ignored, that untrusted stale file would still be sitting at
+ * {@link archivePath} when `downloadArchive` runs next, and
+ * `moveIntoPlace` could mistake it for already-verified bytes —
+ * reopening the exact gap this function closes.
+ * @param url Source URL used to derive the checksum lookup.
+ * @param archivePath Path to the existing cached file to verify.
+ * @returns `true` when the file's checksum matches and it was kept;
+ *   `false` when it did not (or could not be verified) and was removed.
+ */
+export const verifyCachedArchive = async (
+  url: string,
+  archivePath: string,
+): Promise<boolean> => {
+  try {
+    const expectedChecksum = await fetchExpectedChecksum(url);
+    const actualChecksum = await hashFile(archivePath);
+    if (actualChecksum === expectedChecksum) {
+      return true;
+    }
+  } catch {
+    // Falls through to the same stale-file cleanup as a genuine
+    // checksum mismatch -- see the self-healing rationale above.
+  }
+  await rm(archivePath, { force: true });
+  return false;
+};

--- a/packages/sea-builder/src/utils/verifyCachedArchive.spec.mts
+++ b/packages/sea-builder/src/utils/verifyCachedArchive.spec.mts
@@ -1,0 +1,82 @@
+import { createHash } from 'node:crypto';
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { verifyCachedArchive } from './verifyCachedArchive.mjs';
+
+const ARCHIVE_CONTENT = 'fake-archive-bytes';
+const ARCHIVE_NAME = 'node-v22.23.2-linux-x64.tar.gz';
+const ARCHIVE_HASH = createHash('sha256').update(ARCHIVE_CONTENT).digest('hex');
+const ARCHIVE_URL = `https://nodejs.org/dist/v22.23.2/${ARCHIVE_NAME}`;
+
+const shasumsResponse = (body: string, ok = true, status = 200) => ({
+  ok,
+  status,
+  text: async () => body,
+});
+
+let dir: string;
+let archivePath: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'verify-cached-archive-'));
+  archivePath = join(dir, ARCHIVE_NAME);
+  writeFileSync(archivePath, ARCHIVE_CONTENT);
+});
+
+afterEach(() => {
+  rmSync(dir, { force: true, recursive: true });
+  vi.unstubAllGlobals();
+});
+
+describe('verifyCachedArchive', () => {
+  it('keeps the file and returns true on a matching checksum', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => shasumsResponse(`${ARCHIVE_HASH}  ${ARCHIVE_NAME}\n`)),
+    );
+
+    await expect(verifyCachedArchive(ARCHIVE_URL, archivePath)).resolves.toBe(
+      true,
+    );
+    expect(existsSync(archivePath)).toBe(true);
+  });
+
+  it('removes the file and returns false on a checksum mismatch', async () => {
+    const wrongChecksum = 'd'.repeat(64);
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => shasumsResponse(`${wrongChecksum}  ${ARCHIVE_NAME}\n`)),
+    );
+
+    await expect(verifyCachedArchive(ARCHIVE_URL, archivePath)).resolves.toBe(
+      false,
+    );
+    expect(existsSync(archivePath)).toBe(false);
+  });
+
+  it('removes the file and returns false when SHASUMS256.txt cannot be fetched', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => shasumsResponse('', false, 404)),
+    );
+
+    await expect(verifyCachedArchive(ARCHIVE_URL, archivePath)).resolves.toBe(
+      false,
+    );
+    expect(existsSync(archivePath)).toBe(false);
+  });
+
+  it('removes the file and returns false when no checksum entry names the archive', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => shasumsResponse('deadbeef  some-other-file.tar.gz\n')),
+    );
+
+    await expect(verifyCachedArchive(ARCHIVE_URL, archivePath)).resolves.toBe(
+      false,
+    );
+    expect(existsSync(archivePath)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

`createTaskFactory.mts`'s cache-hit check was a bare `existsSync` with
no re-verification. Now that `sea-builder` shares its cache directory
and filename convention with `xsea` (#156), and `xsea`'s own `fetch` →
write has no integrity check of its own, a file already sitting at a
cache slot was trusted outright — silently defeating #57's original
supply-chain hardening whenever `sea-builder` lost the race to populate
that slot.

This PR extracts `downloadArchive.mts`'s checksum-lookup logic
(`findExpectedChecksum` plus the `SHASUMS256.txt` fetch) into two
reusable `utils/` modules, adds a new `verifyCachedArchive(url,
archivePath)` that hashes an existing cache-hit file and compares it
against the published checksum, and wires it into `createTaskFactory`
in place of the bare `existsSync` check:

- Match → the file is kept, `download` is skipped.
- Mismatch, or any error fetching/parsing `SHASUMS256.txt` → the stale
  file is removed and the task falls through to the existing verified
  `download` path (self-heals rather than throwing, matching
  `downloadArchive`'s own recovery philosophy for an interrupted
  download).

`verifyCachedArchive` is threaded through as a new injectable option
(`createTaskFactory` → `createCacheTasks`/`normalizeCacheOptions` →
`normalizeBuildOptions`/`createBuildTasks`), mirroring the existing
`download`/`existsSync`/`mkdir` pattern.

Also corrects a now-stale line in the package README that said an
already-present archive "is not re-verified" — true before this PR,
no longer accurate.

Closes #188

## Rationale / accepted trade-offs

- **No verification logic is duplicated.** `fetchExpectedChecksum` is
  the single place both `downloadArchive`'s download-time verification
  and the new cache-hit re-verification fetch/parse
  `SHASUMS256.txt`. The first commit is a pure extraction —
  `downloadArchive.spec.mts` passes unedited, proving behavior is
  unchanged before the new feature commit lands.
- **A cache hit now costs one `SHASUMS256.txt` fetch plus a local file
  hash, instead of zero network calls.** Intentional — matches the
  zero-tolerance verification stance already in `downloadArchive`
  (no partial trust, no skip-if-plausible shortcuts), per the issue's
  explicit acceptance criterion.
- **A mismatch fetches `SHASUMS256.txt` twice** (once in
  `verifyCachedArchive` to detect the mismatch, once more in the
  `download` it falls through to). Deduplicating this would mean
  changing `DownloadFunction`'s signature to also accept a
  pre-fetched checksum, which is worse than the extra fetch — this
  only happens on the rare stale/foreign-file path, not on every
  build.
- **The stale-file `rm` on a failed verification is not swallowed.**
  `downloadArchive`'s `moveIntoPlace` treats an already-present
  destination as evidence a concurrent caller already
  checksum-verified it (its Windows `EPERM`/`EBUSY` recovery path). A
  silently-ignored `rm` failure would leave the untrusted file in
  place for that heuristic to mistake for verified bytes — see
  `verifyCachedArchive`'s doc comment for the full rationale.

## Test plan

- [x] `pnpm run lint:fix` then `pnpm run lint`
- [x] `pnpm run build`
- [x] `pnpm run test` (102/102 passing, including new coverage for a
      cache hit with a matching checksum, a cache hit with a
      mismatched checksum, and an unchanged cache-miss path)
